### PR TITLE
allow table to be passed to store using db-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,45 @@ Add to your dependencies:
                             (map byte (slurp input-stream)))
             {:sync? false}))
 ```
+## Multitenancy
+To enable the use of the same JDBC database for multiple stores all jdbc specs accept a table name.
+The table can specified separately or passed in the `db-spec`. 
+
+``` clojure
+(def pg-cfg  {:dbtype  "postgresql"
+              :jdbcUrl "postgresql://user:password@localhost/konserve"})
+
+(def store-a (connect-jdbc-store pg-cfg :table "this_application" :opts {:sync? true}))
+(def store-b (connect-jdbc-store pg-cfg :table "that_application" :opts {:sync? true}))
+
+(def pg-cfg-a  {:dbtype  "postgresql"
+                :jdbcUrl "postgresql://user:password@localhost/konserve"
+                :table   "this_application"})
+
+
+(def pg-cfg-b  {:dbtype  "postgresql"
+                :jdbcUrl "postgresql://user:password@localhost/konserve"
+                :table   "that_application"})
+
+
+(def also-store-a (connect-jdbc-store pg-cfg-a :opts {:sync? true}))
+(def also-store-b (connect-jdbc-store pg-cfg-b :opts {:sync? true}))
+```
+In terms of priority a table specified using the keyword argument takes priority, followed
+by the one specified in the `db-spec`. If no table is specified `konserve` is used as the table name.
+
+``` clojure
+(def cfg-a  {:dbtype  "postgresql"
+             :jdbcUrl "postgresql://user:password@localhost/konserve"})
+
+(def cfg-b  {:dbtype  "postgresql"
+             :jdbcUrl "postgresql://user:password@localhost/konserve"
+             :table   "water"})
+
+(def store-a (connect-jdbc-store cfg-a :opts {:sync? true})) ;; table name => konserve
+(def store-b (connect-jdbc-store cfg-b :opts {:sync? true}))  ;; table name => water 
+(def store-c (connect-jdbc-store cfg-b :table "fire" :opts {:sync? true})) ;;table name => fire
+``````
 
 ## Supported Databases
 
@@ -90,21 +129,27 @@ Fully supported so far are the following databases:
 1) PostgreSQL
 
 ``` clojure
-(def pg {:dbtype "postgresql"
-         :dbname "konserve"
-         :host "localhost"
-         :user "konserve"
-         :password "password"})
+(def pg-cfg  {:dbtype "postgresql"
+              :dbname "konserve"
+              :host "localhost"
+              :user "user"
+              :password "password"})
+
+(def pg-url  {:dbtype  "postgresql"
+              :jdbcUrl "postgresql://user:password@localhost/konserve"})
 ```
 
 2) MySQL
 
 ``` clojure
-(def mysql {:dbtype "mysql"
-            :dbname "konserve"
-            :host "localhost"
-            :user "konserve"
-            :password "password"})
+(def mysql-cfg {:dbtype "mysql"
+                :dbname "konserve"
+                :host "localhost"
+                :user "user"
+                :password "password"})
+
+(def mysql-url {:dbtype  "mysql"
+                :jdbcUrl "mysql://user:password@localhost/konserve"})
 ```
 
 3) SQlite

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -267,9 +267,9 @@
       new-spec)))
 
 (defn connect-store [db-spec & {:keys [table opts]
-                                :or {table default-table}
                                 :as params}]
-  (let [db-spec (prepare-spec db-spec)]
+  (let [table (or table (:table db-spec) default-table)
+        db-spec (prepare-spec db-spec)]
     (when-not (:dbtype db-spec)
       (throw (ex-info ":dbtype must be explicitly declared" {:options dbtypes})))
 
@@ -307,8 +307,9 @@
                (.close ^PooledDataSource (:connection ^JDBCTable (:backing store)))
                (remove-from-pool (:db-spec ^JDBCTable (:backing store))))))
 
-(defn delete-store [db-spec & {:keys [table opts] :or {table default-table}}]
+(defn delete-store [db-spec & {:keys [table opts]}]
   (let [complete-opts (merge {:sync? true} opts)
+        table (or table (:table db-spec) default-table)
         connection (jdbc/get-connection (prepare-spec db-spec))
         backing (JDBCTable. db-spec connection table)]
     (-delete-store backing complete-opts)))

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -299,6 +299,8 @@
                         (dissoc params :opts :config))]
       (connect-default-store backing config))))
 
+(def connect-jdbc-store connect-store) ;; this is the new standard approach for store. Old signature remains for backwards compatability. 
+
 (defn release
   "Must be called after work on database has finished in order to close connection"
   [store env]

--- a/test/konserve_jdbc/core_mysql_test.clj
+++ b/test/konserve_jdbc/core_mysql_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.core.async :refer [<!!]]
             [konserve.compliance-test :refer [compliance-test]]
-            [konserve-jdbc.core :refer [connect-store release delete-store]]
+            [konserve-jdbc.core :refer [connect-store release delete-store connect-jdbc-store]]
             [konserve.core :as k]))
 
 (def db-spec
@@ -51,5 +51,13 @@
              (k/get-in store2 [:bar] nil {:sync? true})))
       (is (not= (k/get-in store2 [:bar] nil {:sync? true})
                 (k/get-in store3 [:bar] nil {:sync? true}))))
+    (release store {:sync? true})
+    (delete-store jdbc-url :opts {:sync? true})))
+
+(deftest connect-jdbc-store-test
+  (let [_ (delete-store jdbc-url :table "compliance_test" :opts {:sync? true})
+        store  (connect-jdbc-store jdbc-url :table "compliance_test" :opts {:sync? true})]
+    (testing "Compliance test with synchronous store"
+      (compliance-test store))
     (release store {:sync? true})
     (delete-store jdbc-url :opts {:sync? true})))

--- a/test/konserve_jdbc/core_mysql_test.clj
+++ b/test/konserve_jdbc/core_mysql_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.core.async :refer [<!!]]
             [konserve.compliance-test :refer [compliance-test]]
-            [konserve-jdbc.core :refer [connect-store release delete-store]]))
+            [konserve-jdbc.core :refer [connect-store release delete-store]]
+            [konserve.core :as k]))
 
 (def db-spec
   {:dbtype "mysql"
@@ -35,5 +36,20 @@
         store  (connect-store jdbc-url :table "compliance_test" :opts {:sync? true})]
     (testing "Compliance test with synchronous store"
       (compliance-test store))
+    (release store {:sync? true})
+    (delete-store jdbc-url :opts {:sync? true})))
+
+(deftest table-test
+  (let [jdbc-url2 (assoc jdbc-url :table "convenient_table")
+        _ (delete-store jdbc-url :table "convenient_table" :opts {:sync? true})
+        store  (connect-store jdbc-url :table "convenient_table" :opts {:sync? true})
+        store2  (connect-store jdbc-url2 :opts {:sync? true})
+        store3  (connect-store jdbc-url2 :table "priority_table" :opts {:sync? true})
+        _ (k/assoc-in store [:bar] 42 {:sync? true})]
+    (testing "Testing multiple stores in single db with synchronous store"
+      (is (= (k/get-in store  [:bar] nil {:sync? true})
+             (k/get-in store2 [:bar] nil {:sync? true})))
+      (is (not= (k/get-in store2 [:bar] nil {:sync? true})
+                (k/get-in store3 [:bar] nil {:sync? true}))))
     (release store {:sync? true})
     (delete-store jdbc-url :opts {:sync? true})))


### PR DESCRIPTION
Currently `datahike` cannot differentiate between the different tables in the jdbc database as the identity doesn't include the table name. This change allows the table name to be passed in the `db-spec`. The table name can then be part of the store signature. 

This changes the priority of the table name selection but in a non-breaking way.
Currently:  
 1. `:table` 
 2. `default-table`

After this change:  
1. `:table`  
2. `(-> db-spec :table)`
3. `default-table`