### PR TITLE
Fetch everything during a read in one go

### DIFF
--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -179,10 +179,10 @@
     (if (:sync? env) true (go-try- true)))                       ;; May not return nil, otherwise eternal retries
   (-read-header [_ env]
     (async+sync (:sync? env) *default-sync-translation*
-                (go-try- 
-                  (when-not @cache
-                    (reset! cache (read-all (:dbtype (:db-spec table)) (:connection table) (:table table) key)))
-                  (-> @cache :header))))
+                (go-try-
+                 (when-not @cache
+                   (reset! cache (read-all (:dbtype (:db-spec table)) (:connection table) (:table table) key)))
+                 (-> @cache :header))))
   (-read-meta [_ _meta-size env]
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try- (-> @cache :meta))))

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -151,12 +151,19 @@
                   :size nil})
       (extract-bytes res db-type))))
 
+(defn read-all [db-type connection table id]
+  (let [res (-> (jdbc/execute! connection
+                               [(str "SELECT id, header, meta, val FROM " table " WHERE id = '" id "';")]
+                               {:builder-fn rs/as-unqualified-lower-maps})
+                first)]
+    (into {} (for [[k v] res] [k (if (= k :id) v (extract-bytes v db-type))]))))
+
 (extend-protocol PBackingLock
   Boolean
   (-release [_ env]
     (if (:sync? env) nil (go-try- nil))))
 
-(defrecord JDBCRow [table key data]
+(defrecord JDBCRow [table key data cache]
   PBackingBlob
   (-sync [_ env]
     (async+sync (:sync? env) *default-sync-translation*
@@ -172,17 +179,20 @@
     (if (:sync? env) true (go-try- true)))                       ;; May not return nil, otherwise eternal retries
   (-read-header [_ env]
     (async+sync (:sync? env) *default-sync-translation*
-                (go-try- (read-field (:dbtype (:db-spec table)) (:connection table) (:table table) key :header))))
+                (go-try- 
+                  (when-not @cache
+                    (reset! cache (read-all (:dbtype (:db-spec table)) (:connection table) (:table table) key)))
+                  (-> @cache :header))))
   (-read-meta [_ _meta-size env]
     (async+sync (:sync? env) *default-sync-translation*
-                (go-try- (read-field (:dbtype (:db-spec table)) (:connection table) (:table table) key :meta))))
+                (go-try- (-> @cache :meta))))
   (-read-value [_ _meta-size env]
     (async+sync (:sync? env) *default-sync-translation*
-                (go-try- (read-field (:dbtype (:db-spec table)) (:connection table) (:table table) key :val))))
+                (go-try- (-> @cache :val))))
   (-read-binary [_ _meta-size locked-cb env]
     (async+sync (:sync? env) *default-sync-translation*
-                (go-try- (read-field (:dbtype (:db-spec table)) (:connection table) (:table table) key :val
-                                     :binary? true :locked-cb locked-cb))))
+                (go-try- (locked-cb {:input-stream (when (-> @cache :val) (ByteArrayInputStream. (-> @cache :val)))
+                                     :size nil}))))
   (-write-header [_ header env]
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try- (swap! data assoc :header header))))
@@ -200,7 +210,7 @@
   PBackingStore
   (-create-blob [this store-key env]
     (async+sync (:sync? env) *default-sync-translation*
-                (go-try- (JDBCRow. this store-key (atom {})))))
+                (go-try- (JDBCRow. this store-key (atom {}) (atom nil)))))
   (-delete-blob [_ store-key env]
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try- (jdbc/execute! connection


### PR DESCRIPTION
At the moment header, metadata and value are fetched sequentially, when needed, but this could be done at once to reduce latency. This significantly impacts the performance of the store. 

This change fixes [#9] in a non-breaking manner. 