### PR TITLE
preserve options passed through jdbcUrl

### DIFF
--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -275,7 +275,7 @@
                                             (get (:dbtype spec))
                                             :port))))
           final-jdbc-url (-> new-spec connection/jdbc-url)
-          final-spec (assoc db :jdbcUrl final-jdbc-url :dbtype (:dbtype new-spec))]; (str (when-not (str/blank? options) "&") options))]
+          final-spec (assoc db :jdbcUrl final-jdbc-url :dbtype (:dbtype new-spec))]
       final-spec)))
 
 (defn connect-store [db-spec & {:keys [table opts]

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -10,7 +10,7 @@
             [next.jdbc :as jdbc]
             [next.jdbc.result-set :as rs]
             [next.jdbc.connection :as connection]
-            [taoensso.timbre :refer [warn debug]]
+            [taoensso.timbre :refer [warn debug] :as timbre]
             [hasch.core :as hasch]
             [clojure.string :as str])
   (:import [java.sql Blob]
@@ -273,8 +273,10 @@
                                         port
                                         (-> connection/dbtypes
                                             (get (:dbtype spec))
-                                            :port))))]
-      new-spec)))
+                                            :port))))
+          final-jdbc-url (-> new-spec connection/jdbc-url)
+          final-spec (assoc db :jdbcUrl final-jdbc-url :dbtype (:dbtype new-spec))]; (str (when-not (str/blank? options) "&") options))]
+      final-spec)))
 
 (defn connect-store [db-spec & {:keys [table opts]
                                 :as params}]

--- a/test/konserve_jdbc/core_postgres_test.clj
+++ b/test/konserve_jdbc/core_postgres_test.clj
@@ -14,6 +14,9 @@
 (def jdbc-url
   {:jdbcUrl "postgresql://alice:foo@localhost/config-test"})
 
+(def jdbc-url-2
+  {:jdbcUrl "postgresql://alice:foo@localhost/config-test?sslmode=disable"})
+
 (deftest jdbc-compliance-sync-test
   (let [_ (delete-store db-spec :table "compliance_test"  :opts {:sync? true})
         store  (connect-store db-spec :table "compliance_test" :opts {:sync? true})]
@@ -33,6 +36,14 @@
 (deftest jdbc-url-test
   (let [_ (delete-store jdbc-url :table "compliance_test" :opts {:sync? true})
         store  (connect-store jdbc-url :table "compliance_test" :opts {:sync? true})]
+    (testing "Compliance test with synchronous store"
+      (compliance-test store))
+    (release store {:sync? true})
+    (delete-store jdbc-url :opts {:sync? true})))
+
+(deftest jdbc-url-test-with-options
+  (let [_ (delete-store jdbc-url-2 :table "compliance_test" :opts {:sync? true})
+        store  (connect-store jdbc-url-2 :table "compliance_test" :opts {:sync? true})]
     (testing "Compliance test with synchronous store"
       (compliance-test store))
     (release store {:sync? true})


### PR DESCRIPTION
"konserve-jdbc uses `connection/uri->db-spec` internally which seems to ignore ?sslmode=disable from the :jdbcUrl. Can’t see how to propagate down this setting to disable ssl"

This update uses to extract the authentication details and then reconstitutes the jdbcUrl so no additional parameters are lost. It doesn't change any input parameters and none of the old tests have been modified so it should not be a breaking change. 