### PR TITLE
make function public so datahike-jdbc can use it to generate signature

### DIFF
--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -258,7 +258,7 @@
                                                    {:builder-fn rs/as-unqualified-lower-maps})]
                            (map :id res'))))))
 
-(defn- prepare-spec [db]
+(defn prepare-spec [db]
   ;; next.jdbc does not officially support the credentials in the format: driver://user:password@host/db
   ;; connection/uri->db-spec makes is possible but is rough around the edges
   ;; https://github.com/seancorfield/next-jdbc/issues/229


### PR DESCRIPTION
Currently `datahike-jdbc` creates its own config spec in order to generate a signature this is now out of sing with the spec generated by `konserve-jdbc`. This changes will allow `datahike` to use `konserve`'s spec