### PR TITLE
Add multi assoc support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Add to your dependencies:
 (k/get-in store [:bar] nil {:sync? true})
 (k/dissoc store :bar {:sync? true})
 
+;; Multi-key atomic operations
+(k/multi-assoc store {:user1 {:name "Alice"} 
+                       :user2 {:name "Bob"}} 
+                {:sync? true})
+
 (k/append store :error-log {:type :horrible} {:sync? true})
 (k/log store :error-log {:sync? true})
 
@@ -64,6 +69,10 @@ Add to your dependencies:
 (<! (k/update-in store [:bar] inc))
 (<! (k/get-in store [:bar]))
 (<! (k/dissoc store :bar))
+
+;; Multi-key atomic operations
+(<! (k/multi-assoc store {:user1 {:name "Alice"} 
+                           :user2 {:name "Bob"}}))
 
 (<! (k/append store :error-log {:type :horrible}))
 (<! (k/log store :error-log))
@@ -112,6 +121,23 @@ by the one specified in the `db-spec`. If no table is specified `konserve` is us
 (def store-b (connect-jdbc-store cfg-b :opts {:sync? true}))  ;; table name => water 
 (def store-c (connect-jdbc-store cfg-b :table "fire" :opts {:sync? true})) ;;table name => fire
 ``````
+
+## Multi-key Operations
+
+This backend supports atomic multi-key operations through the `multi-assoc` function, which allows you to update multiple keys in a single atomic transaction. This ensures that either all operations succeed or all fail (ACID guarantees).
+
+``` clojure
+;; Update multiple keys atomically in a single transaction
+(k/multi-assoc store {:user1 {:name "Alice"} 
+                      :user2 {:name "Bob"}} 
+               {:sync? true})
+
+;; Or asynchronously
+(<! (k/multi-assoc store {:user1 {:name "Alice"} 
+                          :user2 {:name "Bob"}}))
+```
+
+The implementation uses JDBC transactions to ensure atomicity, making it suitable for use cases that require strong consistency guarantees across multiple keys.
 
 ## Supported Databases
 

--- a/build.clj
+++ b/build.clj
@@ -80,4 +80,4 @@
               :version version
               :jar-file jar-file
               :class-dir class-dir}))
- 
+

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src"]
  :deps {com.taoensso/timbre {:mvn/version "6.1.0"}
         com.fzakaria/slf4j-timbre {:mvn/version "0.3.21"}
-        io.replikativ/konserve {:mvn/version "0.7.319"}
+        io.replikativ/konserve {:mvn/version "0.8.321"}
         io.replikativ/superv.async {:mvn/version "0.3.46"}
         org.clojure/clojure {:mvn/version "1.11.1"}
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.874"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
   mysql:
     image: docker.io/mysql:8

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -1,8 +1,8 @@
 (ns konserve-jdbc.core
   "Address globally aggregated immutable key-value stores(s)."
   (:require [konserve.impl.defaults :refer [connect-default-store]]
-            [konserve.impl.storage-layout :refer [PBackingStore PBackingBlob PBackingLock 
-                                                 PMultiWriteBackingStore -delete-store]]
+            [konserve.impl.storage-layout :refer [PBackingStore PBackingBlob PBackingLock
+                                                  PMultiWriteBackingStore -delete-store]]
             [konserve.compressor :refer [null-compressor]]
             [konserve.encryptor :refer [null-encryptor]]
             [konserve.utils :refer [async+sync *default-sync-translation*]]
@@ -258,26 +258,26 @@
                                                    [(str "SELECT id FROM " table ";")]
                                                    {:builder-fn rs/as-unqualified-lower-maps})]
                            (map :id res')))))
-  
+
   ;; Implementation for atomic multi-key writes
   PMultiWriteBackingStore
   (-multi-write-blobs [this store-key-values env]
     (async+sync (:sync? env) *default-sync-translation*
-      (go-try-
-        (jdbc/with-transaction [tx connection]
-          (let [results (reduce (fn [results [store-key data]]
-                                  (let [{:keys [header meta value]} data
-                                        db-type (:dbtype db-spec)
-                                        ps (update-statement db-type table 
-                                                            store-key header meta value)
-                                        exec-result (jdbc/execute! tx ps)
-                                        success (if (number? (first exec-result))
-                                                 (pos? (first exec-result))
-                                                 true)] ;; successful execute! returns different values in different JDBC drivers
-                                    (assoc results store-key success)))
-                                {}
-                                store-key-values)]
-            results))))))
+                (go-try-
+                 (jdbc/with-transaction [tx connection]
+                   (let [results (reduce (fn [results [store-key data]]
+                                           (let [{:keys [header meta value]} data
+                                                 db-type (:dbtype db-spec)
+                                                 ps (update-statement db-type table
+                                                                      store-key header meta value)
+                                                 exec-result (jdbc/execute! tx ps)
+                                                 success (if (number? (first exec-result))
+                                                           (pos? (first exec-result))
+                                                           true)] ;; successful execute! returns different values in different JDBC drivers
+                                             (assoc results store-key success)))
+                                         {}
+                                         store-key-values)]
+                     results))))))
 
 (defn- prepare-spec [db]
   ;; next.jdbc does not officially support the credentials in the format: driver://user:password@host/db


### PR DESCRIPTION
Fixes #26. This makes use of JDBC transactions to allow konserve (and then datahike) to transact a set of values at once.