### PR TITLE
feat: switch to unified logging lib

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps {io.replikativ/logging {:mvn/version "0.1.3"}
+ :deps {org.replikativ/logging {:mvn/version "0.1.3"}
         org.replikativ/konserve {:mvn/version "0.9.342"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.11.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,5 @@
 {:paths ["src"]
- :deps {com.taoensso/timbre {:mvn/version "6.1.0"}
-        com.fzakaria/slf4j-timbre {:mvn/version "0.3.21"}
+ :deps {io.replikativ/logging {:mvn/version "0.1.3"}
         org.replikativ/konserve {:mvn/version "0.9.342"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.11.1"}

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -13,7 +13,7 @@
             [next.jdbc :as jdbc]
             [next.jdbc.result-set :as rs]
             [next.jdbc.connection :as connection]
-            [taoensso.timbre :refer [warn debug] :as timbre]
+            [replikativ.logging :as log]
             [hasch.core :as hasch]
             [clojure.string :as str])
   (:import [java.sql Blob]
@@ -359,7 +359,7 @@
                  (let [res (try
                              (jdbc/execute! connection [(str "select 1 from " table " limit 1")])
                              (catch Exception _e
-                               (debug (str "Table " table " does not exist. Attempting to create it."))
+                               (log/debug :konserve.jdbc/table-not-found {:table table})
                                nil))]
                    (when (nil? res)
                      (jdbc/execute! connection (create-statement (:dbtype db-spec) table)))))))
@@ -542,12 +542,11 @@
       (throw (ex-info ":dbtype must be explicitly declared" {:options dbtypes})))
 
     (when-not (supported-dbtypes (:dbtype db-spec))
-      (warn "Unsupported database type " (:dbtype db-spec)
-            " - full functionality of store is only guaranteed for following database types: "  supported-dbtypes))
+      (log/warn :konserve.jdbc/unsupported-dbtype {:dbtype (:dbtype db-spec) :supported supported-dbtypes}))
 
     (System/setProperties
      (doto (java.util.Properties. (System/getProperties))
-       (.put "com.mchange.v2.log.MLog" "com.mchange.v2.log.slf4j.Slf4jMLog"))) ;; using  Slf4j allows timbre to control logs.
+       (.put "com.mchange.v2.log.MLog" "com.mchange.v2.log.slf4j.Slf4jMLog")))
 
     (let [complete-opts (merge {:sync? true} opts)
           db-spec (if (:dbtype db-spec)


### PR DESCRIPTION
## Summary
- Replace `taoensso/timbre` with `io.replikativ/logging` (wrapping `taoensso/trove`)
- Convert all log calls to structured format with mandatory keyword IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)