### PR TITLE
feat(read): PReadMissSafe — one SELECT per read (skip the probe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable, user-visible changes to konserve-jdbc are documented here.
+
+## Unreleased
+
+### Added
+- **Read-miss-safe reads (one SELECT, no probe).** The JDBC backing implements
+  konserve's `PReadMissSafe` and `-read-header` throws `store-key-not-found-ex` when
+  the row is absent (the SELECT returns no rows). On a konserve that supports the
+  marker the redundant `-blob-exists?` SELECT probe is dropped, so a read is one
+  SELECT, and read-modify-write ops (`update-in` / `assoc-in` / `bassoc`) skip it too.
+  Requires konserve `0.9.354`+.
+
+### Changed
+- konserve `0.9.342` → `0.9.354`.

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.replikativ/logging {:mvn/version "0.1.3"}
-        org.replikativ/konserve {:mvn/version "0.9.342"}
+        org.replikativ/konserve {:mvn/version "0.9.354"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.11.1"}
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.874"}

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -3,6 +3,7 @@
   (:require [konserve.impl.defaults :refer [connect-default-store]]
             [konserve.impl.storage-layout :refer [PBackingStore PBackingBlob PBackingLock
                                                   PMultiWriteBackingStore PMultiReadBackingStore
+                                                  PReadMissSafe store-key-not-found-ex
                                                   -delete-store]]
             [konserve.compressor :refer [null-compressor]]
             [konserve.encryptor :refer [null-encryptor]]
@@ -291,6 +292,11 @@
                 (go-try-
                  (when-not (:header @cache)
                    (reset! cache (read-operation env (:dbtype (:db-spec table)) (:connection table) (:table table) key)))
+                 ;; PReadMissSafe: a missing row yields an empty result (no :header).
+                 ;; Signal not-found; io-operation's read-first path converts it to
+                 ;; the caller's :not-found.
+                 (when (nil? (:header @cache))
+                   (throw (store-key-not-found-ex key)))
                  (-> @cache :header))))
   (-read-meta [_ _meta-size env]
     (async+sync (:sync? env) *default-sync-translation*
@@ -513,6 +519,13 @@
                                                {}
                                                (partition-all batch-size store-keys))]
                        all-results)))))))
+
+;; JDBC reads are read-miss-safe: -create-blob only constructs a JDBCRow (no side
+;; effect), and -read-header throws store-key-not-found-ex when the row is absent
+;; (the SELECT returns no rows). So io-operation skips the -blob-exists? SELECT
+;; probe — a read is one SELECT, and update-in/assoc-in/bassoc drop their probe too.
+(extend-type JDBCTable
+  PReadMissSafe)
 
 (defn- prepare-spec [db]
   ;; next.jdbc does not officially support the credentials in the format: driver://user:password@host/db

--- a/test/konserve_jdbc/core_postgres_test.clj
+++ b/test/konserve_jdbc/core_postgres_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.core.async :refer [<!!]]
             [konserve.compliance-test :refer [compliance-test]]
-            [konserve-jdbc.core :refer [release]]
+            [konserve.impl.storage-layout :as sl]
+            [konserve-jdbc.core :as jc :refer [release]]
             [konserve.store :as store]
             [konserve-jdbc.util :refer [test-multi-operations-sync
                                         test-multi-operations-async
@@ -81,3 +82,6 @@
       (test-multi-operations-async store "PostgreSQL" default-num-keys))
     (<!! (release store {:sync? false}))
     (<!! (store/delete-store spec {:sync? false}))))
+(deftest jdbc-read-miss-safe-marker-test
+  (testing "JDBC backing implements PReadMissSafe (io-operation skips the -blob-exists? SELECT probe on reads)"
+    (is (satisfies? sl/PReadMissSafe (jc/->JDBCTable nil nil nil)))))


### PR DESCRIPTION
Implements konserve's `PReadMissSafe` for JDBC: `-read-header` throws `store-key-not-found-ex` when the row is absent, so `io-operation` skips the redundant `-blob-exists?` SELECT probe — a read is one SELECT, and read-modify-write ops drop their probe too. Bumps konserve to `0.9.354`. No CI change needed — the existing `integrationtest-postgresql-mysql-mssql` job already runs the compliance suite and gates deploy. Verified locally against postgres: **7 tests / 487 assertions / 0 failures** (sync + async), backing satisfies `PReadMissSafe`.