### PR TITLE
Conditional writes: the database compares, in the same statement as the write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable, user-visible changes to konserve-jdbc are documented here.
 ## Unreleased
 
 ### Added
+- **Conditional writes (`:expected-revision`).** The backing implements konserve's
+  `PConditionalWrite` and `PSelfConditionalWrite`: a fenced write is one
+  `UPDATE ... WHERE id = ? AND meta = ?`, so the database compares and writes in the
+  same statement, and create-if-absent is an `INSERT` refused by the primary key.
+  No version column and no schema change — existing tables work unchanged. Losing
+  the comparison yields `{:type :konserve/revision-mismatch}`.
+
+  The domain follows the database: `:global` for PostgreSQL, YugabyteDB, MySQL and
+  SQL Server, `:machine` for SQLite and file-based H2, `:process` for in-memory H2.
+  A `:dbtype` outside that set gets no domain and `:expected-revision` is refused
+  rather than ignored. Requires konserve `0.9.376`+.
+
+  Two dialect details, both measured rather than assumed: SQL Server's `varbinary`
+  comparison ignores trailing zero bytes, so the statement compares `DATALENGTH`
+  too; and SQLite reports a duplicate key with no SQLSTATE at all, so the refusal
+  is recognised by its vendor code as well as by SQLSTATE class 23.
+
 - **Read-miss-safe reads (one SELECT, no probe).** The JDBC backing implements
   konserve's `PReadMissSafe` and `-read-header` throws `store-key-not-found-ex` when
   the row is absent (the SELECT returns no rows). On a konserve that supports the
@@ -13,4 +30,4 @@ All notable, user-visible changes to konserve-jdbc are documented here.
   Requires konserve `0.9.354`+.
 
 ### Changed
-- konserve `0.9.342` → `0.9.354`.
+- konserve `0.9.342` → `0.9.376`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ All notable, user-visible changes to konserve-jdbc are documented here.
   too; and SQLite reports a duplicate key with no SQLSTATE at all, so the refusal
   is recognised by its vendor code as well as by SQLSTATE class 23.
 
+  Existing tables work unchanged, but an existing KEY carries no revision until it
+  is written once: the token is part of the metadata this konserve version
+  introduced, and konserve refuses to fence a key that predates it
+  (`:konserve/revision-unavailable`) rather than guess that it is unchanged.
+
+  Not fenceable, and each says so rather than ignoring the option: `bassoc`
+  (konserve's own policy for binary values), `multi-assoc`, and `multi-dissoc`.
+
 - **Read-miss-safe reads (one SELECT, no probe).** The JDBC backing implements
   konserve's `PReadMissSafe` and `-read-header` throws `store-key-not-found-ex` when
   the row is absent (the SELECT returns no rows). On a konserve that supports the
@@ -30,4 +38,13 @@ All notable, user-visible changes to konserve-jdbc are documented here.
   Requires konserve `0.9.354`+.
 
 ### Changed
+- **`:config {:in-place? false}` is now refused at connect time.** It never worked
+  on this backend — the layout renames `<key>.new` over `<key>`, but a rename is
+  `UPDATE ... SET id = ?` and the primary key refuses it whenever the destination
+  row exists, so the second write to any key failed. It would also have bypassed
+  the fence silently. An explicit error replaces both.
+- `konserve-jdbc.core/->JDBCTable` takes a fourth positional argument (the
+  conditional-write read cache). Code that constructs the record directly rather
+  than through `connect-store` needs updating; `connect-store` itself is
+  unchanged.
 - konserve `0.9.342` → `0.9.376`.

--- a/README.md
+++ b/README.md
@@ -245,12 +245,40 @@ konserve exposes that as the store's conditional-write domain:
 | Database | Domain | Orders writers |
 |---|---|---|
 | PostgreSQL, YugabyteDB, MySQL, SQL Server | `:global` | anywhere that can reach the server |
+| H2 over `tcp://` or `ssl://` | `:global` | anywhere that can reach the server |
 | SQLite, file-based H2 | `:machine` | processes on the host holding the file |
-| In-memory H2 | `:process` | one runtime |
+| H2 `mem:`, SQLite `:memory:` | `:process` | one runtime |
 
-A `:dbtype` not in that table gets no domain, and `:expected-revision` is
-refused rather than silently ignored. SQLite over a network filesystem is
-`:machine` at best — its own documentation calls locking there unreliable.
+The domain is read from the deployment, not just the `:dbtype`, because one
+dbtype spells three different things: an embedded H2 file orders every process
+on the host, an H2 `mem:` database is invisible to the process next door, and an
+H2 server orders writers anywhere on the network.
+
+A `:dbtype` this backend does not recognise gets no domain, and
+`:expected-revision` is refused rather than silently ignored. SQLite over a
+network filesystem is `:machine` at best — its own documentation calls locking
+there unreliable.
+
+### Limits
+
+- **Existing keys must be written once before they can be fenced.** The revision
+  lives in konserve's metadata and was introduced with this feature, so a key
+  last written by an older release has none. Fencing it raises
+  `:konserve/revision-unavailable` — a deliberate refusal rather than a guessed
+  "unchanged". One ordinary write gives the key a revision; the table itself
+  needs no migration.
+- **Binary values cannot be fenced.** `konserve.core/bassoc` refuses
+  `:expected-revision` in konserve itself, so a pointer stored with `bassoc` gets
+  no fencing on any backend.
+- **Multi-key operations cannot be fenced.** `multi-assoc` and `multi-dissoc`
+  both refuse the option; there is nothing coherent to compare across a batch.
+- **`:config {:in-place? false}` is refused at connect time.** That layout writes
+  `<key>.new` and renames it into place, but a rename here is `UPDATE ... SET id`
+  and the primary key rejects it whenever the destination exists — so the second
+  write to any key failed, with or without fencing. It is now an error rather
+  than a surprise.
+- **`:jdbcUrl` with H2 does not work** (pre-existing): `connection/uri->db-spec`
+  returns no `:dbtype` for `jdbc:h2:` URLs. Use `:dbtype "h2"` with `:dbname`.
 
 ## Supported Databases
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,49 @@ This backend supports atomic multi-key operations (`multi-assoc`, `multi-get`, `
 
 **Transaction Support**: All operations are wrapped in JDBC transactions for atomicity. Uses bulk INSERT/UPSERT statements for efficient writes. Connection pooling via c3p0 is used by default for concurrent access. Database-specific SQL syntax is handled automatically.
 
+## Conditional Writes
+
+Two processes that read the same key and then both write it will, by default,
+leave whichever wrote last — the other update is gone, and neither writer is
+told. Passing `:expected-revision` makes the write conditional on the key still
+holding what was read:
+
+``` clojure
+(require '[konserve.core :as k])
+
+(let [[value revision] (k/get store :head nil {:sync? true :with-revision? true})]
+  (k/assoc store :head (update value :n inc)
+           {:sync? true :expected-revision revision}))
+;; => throws ex-info with {:type :konserve/revision-mismatch} if someone else
+;;    committed in between; re-read and retry.
+```
+
+`konserve.core/absent` as the expected revision means *create it only if it does
+not exist*.
+
+The comparison is made by the database, in the same statement as the write:
+
+``` sql
+UPDATE konserve SET header = ?, meta = ?, val = ? WHERE id = ? AND meta = ?
+```
+
+If no row matches, nothing was written and the caller is told. Create-if-absent
+is a plain `INSERT` refused by the primary key. There is no version column and
+no schema change — an existing table works as it is.
+
+**How far the fence reaches** depends on the database, not on this library, and
+konserve exposes that as the store's conditional-write domain:
+
+| Database | Domain | Orders writers |
+|---|---|---|
+| PostgreSQL, YugabyteDB, MySQL, SQL Server | `:global` | anywhere that can reach the server |
+| SQLite, file-based H2 | `:machine` | processes on the host holding the file |
+| In-memory H2 | `:process` | one runtime |
+
+A `:dbtype` not in that table gets no domain, and `:expected-revision` is
+refused rather than silently ignored. SQLite over a network filesystem is
+`:machine` at best — its own documentation calls locking there unreliable.
+
 ## Supported Databases
 
 **BREAKING CHANGE**: konserve-jdbc versions after `0.1.79` no longer include

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.replikativ/logging {:mvn/version "0.1.3"}
-        org.replikativ/konserve {:mvn/version "0.9.369"}
+        org.replikativ/konserve {:mvn/version "0.9.376"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.11.1"}
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.874"}

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -125,9 +125,19 @@
    so the vendor code is matched too — narrowly, by driver class name, because
    the number 19 means nothing in particular anywhere else."
   [^java.sql.SQLException e]
-  (or (some-> (.getSQLState e) (subs 0 2) (= "23"))
+  (or (some-> (.getSQLState e) (str/starts-with? "23"))
       (and (= "org.sqlite.SQLiteException" (.getName (class e)))
            (= 19 (.getErrorCode e)))))
+
+(def ^:const fenced-write-operations
+  "The `:operation` values konserve puts in the env of a CONDITIONAL write. The
+   read it takes under the lock to evaluate that write carries the same one, which
+   is what lets the read path tell itself apart from every other read."
+  #{:write-edn :write-binary})
+
+(defn fenced-read? [env]
+  (and (:expected-revision env)
+       (contains? fenced-write-operations (:operation env))))
 
 (defn update-statement [db-type table id header meta value]
   (case db-type
@@ -394,12 +404,20 @@
     ;; closes the row it read from after the write it fenced has finished either
     ;; way — so this is where the entry is guaranteed to go.
     ;;
-    ;; Should that order ever change and the entry disappear too early, the write
-    ;; finds nothing cached, takes the create-if-absent INSERT, and the primary key
-    ;; refuses it: a mismatch reported for a write that was merely mistimed. That
-    ;; is the direction to fail in — the alternative, treating a missing entry as
-    ;; permission to overwrite, is the silent loss the fence exists to prevent.
-    (swap! (:read-cache table) dissoc key)
+    ;; Gated on the SAME predicate as the deposit, and that gate is load-bearing
+    ;; rather than an optimisation. `list-keys` opens and closes a row for every
+    ;; key it enumerates, and `konserve.core/keys` takes no lock at all — so an
+    ;; unguarded eviction here lets an enumeration (or `konserve.gc/sweep!`, which
+    ;; runs through it) delete the entry between a fenced write's read and its
+    ;; `-sync`. Measured before the gate: a SOLE writer doing 300 fenced
+    ;; increments alongside a `k/keys` loop got 17 rejections, none of them real.
+    ;;
+    ;; The failure was in the safe direction — the write turns into the
+    ;; create-if-absent INSERT and the primary key refuses it, so nothing is lost
+    ;; — but a caller cannot tell a manufactured conflict from a true one, and
+    ;; retrying forever is not a fix.
+    (when (fenced-read? env)
+      (swap! (:read-cache table) dissoc key))
     (if (:sync? env) nil (go-try- nil)))
   (-get-lock [_ env]
     (if (:sync? env) true (go-try- true)))                       ;; May not return nil, otherwise eternal retries
@@ -413,12 +431,20 @@
                  ;; the caller's :not-found.
                  (when (nil? (:header @cache))
                    (throw (store-key-not-found-ex key)))
-                 ;; Remember the META for a fenced `-sync`, and only for one. The read
-                 ;; preceding a conditional write carries `:expected-revision` in its
-                 ;; env, so we can tell — caching on every read would hold metadata for
-                 ;; every key a store ever touched.
+                 ;; Remember the META for a fenced `-sync`, and only for that.
+                 ;;
+                 ;; `fenced-read?` is deliberately narrow. `:expected-revision` alone
+                 ;; is not enough: `multi-get` forwards whatever opts it is handed,
+                 ;; takes no per-key lock and never closes its rows, so a multi-read
+                 ;; carrying that option would deposit metadata NEWER than the one an
+                 ;; in-flight fenced write on this store already validated — and that
+                 ;; write would then compare against it and land, which is exactly the
+                 ;; lost update this exists to prevent. Only the read konserve takes
+                 ;; under the lock as part of a conditional write may deposit, and
+                 ;; that read carries the write's own `:operation`.
+                 ;;
                  ;; `read-operation` has already turned an H2 Blob into bytes.
-                 (when (:expected-revision env)
+                 (when (fenced-read? env)
                    (when-let [m (:meta @cache)]
                      (swap! (:read-cache table) assoc key m)))
                  (-> @cache :header))))
@@ -454,30 +480,50 @@
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try- (swap! data assoc :value blob)))))
 
-(def ^:const conditional-write-domains
-  "How far a fenced write reaches, per database. The MECHANISM is the same
-   everywhere — one `UPDATE ... WHERE meta = ?`, evaluated by the database — but
-   the REACH is a property of where that database runs, and this backend talks to
-   several kinds.
-
-   A server on the network is reachable from any host, so its comparison orders
-   every writer anywhere. SQLite is a file: it orders processes on the machine
-   holding it, and no further — and not even that on a network filesystem, where
-   its locking is documented as unreliable. An in-memory H2 has no writers outside
-   its own runtime.
-
-   A database not listed here gets NO domain and `:expected-revision` is refused.
-   The statement would work on any SQL database; what cannot be guessed is how far
-   its answer reaches, and guessing generously is how a deployment comes to believe
-   it is fenced across hosts when it is not."
+(def ^:const server-conditional-write-domains
+  "How far a fenced write reaches, for the databases that are SERVERS. The
+   mechanism is the same everywhere — one `UPDATE ... WHERE meta = ?`, evaluated
+   by the database — but the reach is a property of where that database runs, and
+   a server on the network is reachable from any host, so its comparison orders
+   every writer anywhere."
   {"postgresql" :global
    "yugabytedb" :global
    "mysql"      :global
    "mssql"      :global
-   "sqlserver"  :global
-   "sqlite"     :machine
-   "h2"         :machine
-   "h2:mem"     :process})
+   "sqlserver"  :global})
+
+(defn conditional-write-domain
+  "How far this store's fence reaches: `:global`, `:machine`, `:process`, or nil.
+
+   For the servers it follows the dbtype. For the two embedded databases it
+   cannot, because one dbtype spells three different deployments and the
+   difference is the whole answer:
+
+     - `h2` with a `mem:` name, and sqlite with `:memory:`, live in one JVM heap.
+       A second process on the same host opens an entirely DIFFERENT database, so
+       the honest domain is `:process`. Reporting `:machine` here would be an
+       OVER-claim — a caller asking `(conditional-write? store :machine)` would be
+       told yes about writers that cannot even see this data.
+     - `h2` reached over `tcp://` or `ssl://` is a server like any other, and
+       orders writers anywhere on the network: `:global`.
+     - otherwise both are a file, ordering processes on the host that holds it and
+       no further — and not even that on a network filesystem, where SQLite's own
+       documentation calls locking unreliable.
+
+   A database this does not recognise gets NO domain and `:expected-revision` is
+   refused. The statement would work on any SQL database; what cannot be guessed
+   is how far its answer reaches, and guessing generously is how a deployment
+   comes to believe it is fenced across hosts when it is not."
+  [{:keys [dbtype dbname]}]
+  (let [name* (str/lower-case (str dbname))]
+    (case dbtype
+      "h2" (cond
+             (str/starts-with? name* "mem:") :process
+             (or (str/starts-with? name* "tcp://")
+                 (str/starts-with? name* "ssl://")) :global
+             :else :machine)
+      "sqlite" (if (str/starts-with? name* ":memory:") :process :machine)
+      (get server-conditional-write-domains dbtype))))
 
 (defrecord JDBCTable [db-spec connection table read-cache]
   ;; The database evaluates the comparison — one statement, atomic on its own — so
@@ -488,7 +534,7 @@
 
   protocols/PConditionalWrite
   (-conditional-write-domain [_]
-    (get conditional-write-domains (:dbtype db-spec)))
+    (conditional-write-domain db-spec))
 
   PBackingStore
   (-create-blob [this store-key env]
@@ -511,7 +557,7 @@
                            ;; before `-sync` could spend it. Left behind, it would
                            ;; turn the next create-if-absent into an UPDATE that
                            ;; matches nothing and reports a mismatch that is not one.
-                           (when-not exists?
+                           (when (and (not exists?) (:expected-revision env))
                              (swap! read-cache dissoc store-key))
                            exists?))))
   (-copy [_ from to env]
@@ -607,6 +653,16 @@
   (-multi-delete-blobs [this store-keys env]
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try-
+                 ;; `multi-assoc` refuses `:expected-revision` in konserve itself;
+                 ;; `multi-dissoc` forwards its opts here unchecked, so without this
+                 ;; a caller asking for a fenced batch delete would be told it
+                 ;; happened while the option was quietly dropped. There is nothing
+                 ;; to fence against across a batch — the delete is atomic, the
+                 ;; comparison would not be — so the honest answer is to refuse.
+                 (when (:expected-revision env)
+                   (throw (ex-info "multi-dissoc cannot be made conditional: :expected-revision is not supported for multi-key deletes."
+                                   {:type :konserve/conditional-write-unsupported
+                                    :operation :multi-dissoc})))
                  (if (empty? store-keys)
                    {}
                    (jdbc/with-transaction [tx connection]
@@ -754,6 +810,25 @@
           ;; warning on every connect whatever the caller passed, and filling
           ;; first would let it occupy the slot and silently drop a caller's
           ;; older spelling.
+          _ (when (false? (:in-place? (:config params)))
+              ;; Refused rather than honoured, because this backing cannot do it.
+              ;; The layout writes `<key>.new` and then renames it over `<key>`,
+              ;; but `-atomic-move` is `UPDATE ... SET id = ?` and the primary key
+              ;; refuses that whenever the destination row still exists — so the
+              ;; SECOND write to any key fails. Measured on Postgres: create ok,
+              ;; overwrite `duplicate key value violates unique constraint`.
+              ;;
+              ;; It also breaks the fence. The metadata a conditional write
+              ;; compares is remembered under the real key, so a write aimed at
+              ;; `<key>.new` finds none, takes create-if-absent, and the rename
+              ;; that follows is unconditional — nothing compares anything. Left
+              ;; reachable, that is a silent lost update in a configuration that
+              ;; was already broken for ordinary writes.
+              (throw (ex-info (str ":in-place? false is not supported by konserve-jdbc. A row is "
+                                   "updated in place; the rename this layout needs collides with "
+                                   "the primary key, and a conditional write could not be fenced.")
+                              {:type :konserve.jdbc/unsupported-config
+                               :config (:config params)})))
           config (-> (dissoc params :opts :config)
                      (assoc :config (merge {:sync-blob? true
                                             :in-place? true

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -1,6 +1,7 @@
 (ns konserve-jdbc.core
   "Address globally aggregated immutable key-value stores(s)."
-  (:require [konserve.impl.defaults :refer [connect-default-store normalize-store-config]]
+  (:require [konserve.protocols :as protocols]
+            [konserve.impl.defaults :refer [connect-default-store normalize-store-config]]
             [konserve.impl.storage-layout :refer [PBackingStore PBackingBlob PBackingLock
                                                   PMultiWriteBackingStore PMultiReadBackingStore
                                                   PReadMissSafe store-key-not-found-ex
@@ -67,6 +68,66 @@
           "CREATE TABLE dbo." table " (id varchar(100) primary key, header varbinary(max), meta varbinary(max), val varbinary(max)); "
           "END;")]
     [(str "CREATE TABLE IF NOT EXISTS " table " (id varchar(100) primary key, header longblob, meta longblob, val longblob);")]))
+
+(defn fenced-update-statement
+  "Replace the row for `id`, but only while its `meta` column still holds
+   `expected-meta`. Row count 1 means the write happened, 0 that it was refused.
+
+   ONE statement, so the comparison and the write are the same step — the database
+   evaluates it, which is what makes this backing's guarantee reach as far as the
+   database does. No transaction is needed for that; an UPDATE is atomic on its
+   own.
+
+   The comparison is on the META column rather than a separate version column.
+   konserve's revision lives inside the serialized metadata, so for this row the
+   meta bytes ARE the revision, and comparing them needs no schema change and no
+   migration for existing tables.
+
+   SQL Server needs the length too. Its varbinary comparison treats trailing zero
+   bytes as insignificant, so two values of different lengths can compare EQUAL —
+   which for a fence means a stale write passing. Microsoft's own guidance is to
+   test the length alongside the data, and DATALENGTH is how. The other dialects
+   compare binary exactly: bytea, longblob and SQLite BLOBs are all memcmp."
+  [db-type table id header meta value expected-meta]
+  (case db-type
+    ("mssql" "sqlserver")
+    [(str "UPDATE dbo." table " SET header = ?, meta = ?, val = ? "
+          "WHERE id = ? AND meta = ? AND DATALENGTH(meta) = ?")
+     header meta value id expected-meta (count expected-meta)]
+    [(str "UPDATE " table " SET header = ?, meta = ?, val = ? "
+          "WHERE id = ? AND meta = ?")
+     header meta value id expected-meta]))
+
+(defn fenced-insert-statement
+  "Insert the row for `id`, relying on the PRIMARY KEY to refuse it if the row
+   already exists — which is create-if-absent, evaluated by the database.
+
+   A plain INSERT rather than a dialect-specific upsert precisely because it must
+   NOT overwrite. The refusal arrives as an integrity-constraint violation, which
+   is SQLSTATE class 23 in the standard and in every driver here."
+  [db-type table id header meta value]
+  (case db-type
+    ("mssql" "sqlserver")
+    [(str "INSERT INTO dbo." table " (id, header, meta, val) VALUES (?, ?, ?, ?)")
+     id header meta value]
+    [(str "INSERT INTO " table " (id, header, meta, val) VALUES (?, ?, ?, ?)")
+     id header meta value]))
+
+(defn integrity-violation?
+  "Is this the database refusing a duplicate primary key?
+
+   SQLSTATE class 23 is the standard's integrity-constraint violation. Measured
+   against every database this backend supports: postgres 23505, mysql 23000,
+   h2 23505, sqlserver 23000 — and sqlite, which reports NO SQLSTATE at all
+   (`nil`) and carries the refusal in the vendor code instead, 19 for
+   SQLITE_CONSTRAINT. Missing that case would turn create-if-absent on sqlite
+   from a clean rejection into a raw driver exception the caller cannot classify,
+   so the vendor code is matched too — narrowly, by driver class name, because
+   the number 19 means nothing in particular anywhere else."
+  [^java.sql.SQLException e]
+  (or (some-> (.getSQLState e) (subs 0 2) (= "23"))
+      (and (= "org.sqlite.SQLiteException" (.getName (class e)))
+           (= 19 (.getErrorCode e)))))
 
 (defn update-statement [db-type table id header meta value]
   (case db-type
@@ -276,13 +337,69 @@
   PBackingBlob
   (-sync [_ env]
     (async+sync (:sync? env) *default-sync-translation*
-                (go-try- (let [{:keys [header meta value]} @data]
+                (go-try- (let [{:keys [header meta value]} @data
+                               db-type (:dbtype (:db-spec table))
+                               expected-revision (:expected-revision env)]
                            (if (and header meta value)
-                             (let [ps (update-statement (:dbtype (:db-spec table)) (:table table) key header meta value)]
-                               (jdbc/execute-one! (:connection table) ps))
+                             (if expected-revision
+                               ;; FENCED. konserve has already compared the revision
+                               ;; it read against the caller's; the statement below
+                               ;; closes the window BETWEEN that read and this write,
+                               ;; which is the half no counter can do. Both together
+                               ;; are the compare-and-set.
+                               ;;
+                               ;; What was read is remembered by the read path, since
+                               ;; `-sync` runs on a DIFFERENT row record than the read
+                               ;; did. No entry means no read happened, which for a
+                               ;; fenced write is create-if-absent — and that is a
+                               ;; plain INSERT, refused by the primary key.
+                               (let [cache (:read-cache table)
+                                     expected (get @cache key ::absent)]
+                                 (try
+                                   (if (= ::absent expected)
+                                     (try
+                                       (jdbc/execute-one!
+                                        (:connection table)
+                                        (fenced-insert-statement db-type (:table table) key header meta value))
+                                       (catch java.sql.SQLException e
+                                         (if (integrity-violation? e)
+                                           (throw (ex-info "Conditional write rejected: the key already exists."
+                                                           {:type :konserve/revision-mismatch
+                                                            :key key
+                                                            :expected expected-revision}))
+                                           (throw e))))
+                                     (let [res (jdbc/execute-one!
+                                                (:connection table)
+                                                (fenced-update-statement db-type (:table table) key
+                                                                         header meta value expected))
+                                           updated (:next.jdbc/update-count res 0)]
+                                       (when-not (pos? updated)
+                                         ;; No row matched, so the stored metadata is
+                                         ;; not the one this write was derived from.
+                                         (throw (ex-info (str "Conditional write rejected: the stored metadata is "
+                                                              "not the one this write was derived from.")
+                                                         {:type :konserve/revision-mismatch
+                                                          :key key
+                                                          :expected expected-revision})))))
+                                   (finally
+                                     ;; Whatever happened, this read is spent.
+                                     (swap! cache dissoc key))))
+                               (let [ps (update-statement db-type (:table table) key header meta value)]
+                                 (jdbc/execute-one! (:connection table) ps)))
                              (throw (ex-info "Updating a row is only possible if header, meta and value are set." {:data @data})))
                            (reset! data {})))))
   (-close [_ env]
+    ;; The remembered metadata belongs to ONE operation. `-sync` spends it, but a
+    ;; fenced write whose revision check fails never reaches `-sync`, and konserve
+    ;; closes the row it read from after the write it fenced has finished either
+    ;; way — so this is where the entry is guaranteed to go.
+    ;;
+    ;; Should that order ever change and the entry disappear too early, the write
+    ;; finds nothing cached, takes the create-if-absent INSERT, and the primary key
+    ;; refuses it: a mismatch reported for a write that was merely mistimed. That
+    ;; is the direction to fail in — the alternative, treating a missing entry as
+    ;; permission to overwrite, is the silent loss the fence exists to prevent.
+    (swap! (:read-cache table) dissoc key)
     (if (:sync? env) nil (go-try- nil)))
   (-get-lock [_ env]
     (if (:sync? env) true (go-try- true)))                       ;; May not return nil, otherwise eternal retries
@@ -296,6 +413,14 @@
                  ;; the caller's :not-found.
                  (when (nil? (:header @cache))
                    (throw (store-key-not-found-ex key)))
+                 ;; Remember the META for a fenced `-sync`, and only for one. The read
+                 ;; preceding a conditional write carries `:expected-revision` in its
+                 ;; env, so we can tell — caching on every read would hold metadata for
+                 ;; every key a store ever touched.
+                 ;; `read-operation` has already turned an H2 Blob into bytes.
+                 (when (:expected-revision env)
+                   (when-let [m (:meta @cache)]
+                     (swap! (:read-cache table) assoc key m)))
                  (-> @cache :header))))
   (-read-meta [_ _meta-size env]
     (async+sync (:sync? env) *default-sync-translation*
@@ -329,7 +454,42 @@
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try- (swap! data assoc :value blob)))))
 
-(defrecord JDBCTable [db-spec connection table]
+(def ^:const conditional-write-domains
+  "How far a fenced write reaches, per database. The MECHANISM is the same
+   everywhere — one `UPDATE ... WHERE meta = ?`, evaluated by the database — but
+   the REACH is a property of where that database runs, and this backend talks to
+   several kinds.
+
+   A server on the network is reachable from any host, so its comparison orders
+   every writer anywhere. SQLite is a file: it orders processes on the machine
+   holding it, and no further — and not even that on a network filesystem, where
+   its locking is documented as unreliable. An in-memory H2 has no writers outside
+   its own runtime.
+
+   A database not listed here gets NO domain and `:expected-revision` is refused.
+   The statement would work on any SQL database; what cannot be guessed is how far
+   its answer reaches, and guessing generously is how a deployment comes to believe
+   it is fenced across hosts when it is not."
+  {"postgresql" :global
+   "yugabytedb" :global
+   "mysql"      :global
+   "mssql"      :global
+   "sqlserver"  :global
+   "sqlite"     :machine
+   "h2"         :machine
+   "h2:mem"     :process})
+
+(defrecord JDBCTable [db-spec connection table read-cache]
+  ;; The database evaluates the comparison — one statement, atomic on its own — so
+  ;; konserve adds no mechanism of its own: no sidecar row, no lock. Declared
+  ;; rather than inferred from the domain, since this backend fences itself at
+  ;; three different reaches depending on which database it is talking to.
+  protocols/PSelfConditionalWrite
+
+  protocols/PConditionalWrite
+  (-conditional-write-domain [_]
+    (get conditional-write-domains (:dbtype db-spec)))
+
   PBackingStore
   (-create-blob [this store-key env]
     (async+sync (:sync? env) *default-sync-translation*
@@ -341,8 +501,19 @@
   (-blob-exists? [_ store-key env]
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try- (let [res (jdbc/execute! connection
-                                                  [(str "SELECT 1 FROM " table " WHERE id = ?;") store-key])]
-                           (not (nil? (first res)))))))
+                                                  [(str "SELECT 1 FROM " table " WHERE id = ?;") store-key])
+                               exists? (not (nil? (first res)))]
+                           ;; This probe is what konserve uses, under the lock, to
+                           ;; decide whether a fenced write reads the old row at all.
+                           ;; If the row is gone, no read will follow, so anything
+                           ;; this key left in the read cache is stale — from an
+                           ;; earlier fenced attempt whose revision check failed
+                           ;; before `-sync` could spend it. Left behind, it would
+                           ;; turn the next create-if-absent into an UPDATE that
+                           ;; matches nothing and reports a mismatch that is not one.
+                           (when-not exists?
+                             (swap! read-cache dissoc store-key))
+                           exists?))))
   (-copy [_ from to env]
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try- (jdbc/execute! connection (copy-row-statement (:dbtype db-spec) table to from)))))
@@ -566,7 +737,7 @@
                     (assoc db-spec :dbtype (:subprotocol db-spec)))
           db-spec (assoc db-spec :sync? (:sync? complete-opts))
           ^PooledDataSource connection (get-connection db-spec)
-          backing (JDBCTable. db-spec connection table)
+          backing (JDBCTable. db-spec connection table (atom {}))
           ;; `:config` IS forwarded now. It used to be dissoc'd, so the
           ;; literal above always won and compression and encryption could not
           ;; be configured at all -- the blob header carried a 0 whatever was
@@ -610,7 +781,7 @@
   (let [complete-opts (merge {:sync? true} opts)
         table (or table (:table db-spec) default-table)
         connection (jdbc/get-connection (prepare-spec db-spec))
-        backing (JDBCTable. db-spec connection table)]
+        backing (JDBCTable. db-spec connection table (atom {}))]
     (-delete-store backing complete-opts)))
 
 ;; =============================================================================

--- a/test/konserve_jdbc/core_h2_test.clj
+++ b/test/konserve_jdbc/core_h2_test.clj
@@ -11,6 +11,8 @@
                                         test-concurrent-create-if-absent
                                         test-duplicate-insert-is-classified
                                         test-comparison-is-byte-exact
+                                        test-enumeration-does-not-break-fenced-writes
+                                        test-multi-read-cannot-poison-a-fenced-write
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -66,7 +68,8 @@
     (testing "Conditional write contract on H2"
       (test-conditional-writes #(do (store/delete-store spec {:sync? true})
                                     (store/connect-store spec {:sync? true}))
-                               #(release % {:sync? true})))
+                               #(release % {:sync? true})
+                               :machine))
     (store/delete-store spec {:sync? true})))
 
 (deftest jdbc-concurrent-fenced-counter-test
@@ -96,4 +99,21 @@
       (test-concurrent-create-if-absent #(store/connect-store spec {:sync? true})
                                         #(release % {:sync? true})
                                         4))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-enumeration-vs-fenced-write-test
+  (let [spec (assoc db-spec :table "swept_counter_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "A k/keys sweep does not manufacture conflicts on H2"
+      (test-enumeration-does-not-break-fenced-writes #(store/connect-store spec {:sync? true})
+                                                     #(release % {:sync? true})
+                                                     150))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-multi-read-poisoning-test
+  (let [spec (assoc db-spec :table "poison_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "A multi-read cannot redirect a fenced write on H2"
+      (test-multi-read-cannot-poison-a-fenced-write #(store/connect-store spec {:sync? true})
+                                                    #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_h2_test.clj
+++ b/test/konserve_jdbc/core_h2_test.clj
@@ -6,6 +6,11 @@
             [konserve.store :as store]
             [konserve-jdbc.util :refer [with-dir test-multi-operations-sync
                                         test-multi-operations-async
+                                        test-conditional-writes
+                                        test-concurrent-fenced-counter
+                                        test-concurrent-create-if-absent
+                                        test-duplicate-insert-is-classified
+                                        test-comparison-is-byte-exact
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -54,3 +59,41 @@
       (test-multi-operations-async store "H2" default-num-keys))
     (<!! (release store {:sync? false}))
     (<!! (store/delete-store spec {:sync? false}))))
+
+(deftest jdbc-conditional-write-test
+  (let [spec (assoc db-spec :table "conditional_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Conditional write contract on H2"
+      (test-conditional-writes #(do (store/delete-store spec {:sync? true})
+                                    (store/connect-store spec {:sync? true}))
+                               #(release % {:sync? true})))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-concurrent-fenced-counter-test
+  (let [spec (assoc db-spec :table "fenced_counter_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Concurrent fenced increments on H2 lose nothing"
+      (test-concurrent-fenced-counter #(store/connect-store spec {:sync? true})
+                                      #(release % {:sync? true})
+                                      4 15))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-fence-mechanism-test
+  (let [spec (assoc db-spec :table "fence_mechanism_test")
+        _ (store/delete-store spec {:sync? true})
+        store (store/connect-store spec {:sync? true})]
+    (testing "The database refuses a duplicate key in a way we can classify (H2)"
+      (test-duplicate-insert-is-classified store))
+    (testing "The fenced comparison is byte-exact (H2)"
+      (test-comparison-is-byte-exact store))
+    (release store {:sync? true})
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-concurrent-create-if-absent-test
+  (let [spec (assoc db-spec :table "contested_create_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Contested create-if-absent on H2 has exactly one winner"
+      (test-concurrent-create-if-absent #(store/connect-store spec {:sync? true})
+                                        #(release % {:sync? true})
+                                        4))
+    (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_mssql_test.clj
+++ b/test/konserve_jdbc/core_mssql_test.clj
@@ -5,6 +5,11 @@
             [konserve-jdbc.core :refer [release]]
             [konserve.store :as store]
             [konserve-jdbc.util :refer [test-multi-operations-sync test-multi-operations-async
+                                        test-conditional-writes
+                                        test-concurrent-fenced-counter
+                                        test-concurrent-create-if-absent
+                                        test-duplicate-insert-is-classified
+                                        test-comparison-is-byte-exact
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -52,3 +57,41 @@
       (test-multi-operations-async store "MSSQL" default-num-keys))
     (<!! (release store {:sync? false}))
     (<!! (store/delete-store spec {:sync? false}))))
+
+(deftest jdbc-conditional-write-test
+  (let [spec (assoc db-spec :table "conditional_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Conditional write contract on MSSQL"
+      (test-conditional-writes #(do (store/delete-store spec {:sync? true})
+                                    (store/connect-store spec {:sync? true}))
+                               #(release % {:sync? true})))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-concurrent-fenced-counter-test
+  (let [spec (assoc db-spec :table "fenced_counter_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Concurrent fenced increments on MSSQL lose nothing"
+      (test-concurrent-fenced-counter #(store/connect-store spec {:sync? true})
+                                      #(release % {:sync? true})
+                                      4 15))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-fence-mechanism-test
+  (let [spec (assoc db-spec :table "fence_mechanism_test")
+        _ (store/delete-store spec {:sync? true})
+        store (store/connect-store spec {:sync? true})]
+    (testing "The database refuses a duplicate key in a way we can classify (MSSQL)"
+      (test-duplicate-insert-is-classified store))
+    (testing "The fenced comparison is byte-exact (MSSQL)"
+      (test-comparison-is-byte-exact store))
+    (release store {:sync? true})
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-concurrent-create-if-absent-test
+  (let [spec (assoc db-spec :table "contested_create_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Contested create-if-absent on MSSQL has exactly one winner"
+      (test-concurrent-create-if-absent #(store/connect-store spec {:sync? true})
+                                        #(release % {:sync? true})
+                                        4))
+    (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_mssql_test.clj
+++ b/test/konserve_jdbc/core_mssql_test.clj
@@ -10,6 +10,8 @@
                                         test-concurrent-create-if-absent
                                         test-duplicate-insert-is-classified
                                         test-comparison-is-byte-exact
+                                        test-enumeration-does-not-break-fenced-writes
+                                        test-multi-read-cannot-poison-a-fenced-write
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -64,7 +66,8 @@
     (testing "Conditional write contract on MSSQL"
       (test-conditional-writes #(do (store/delete-store spec {:sync? true})
                                     (store/connect-store spec {:sync? true}))
-                               #(release % {:sync? true})))
+                               #(release % {:sync? true})
+                               :global))
     (store/delete-store spec {:sync? true})))
 
 (deftest jdbc-concurrent-fenced-counter-test
@@ -94,4 +97,21 @@
       (test-concurrent-create-if-absent #(store/connect-store spec {:sync? true})
                                         #(release % {:sync? true})
                                         4))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-enumeration-vs-fenced-write-test
+  (let [spec (assoc db-spec :table "swept_counter_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "A k/keys sweep does not manufacture conflicts on MSSQL"
+      (test-enumeration-does-not-break-fenced-writes #(store/connect-store spec {:sync? true})
+                                                     #(release % {:sync? true})
+                                                     150))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-multi-read-poisoning-test
+  (let [spec (assoc db-spec :table "poison_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "A multi-read cannot redirect a fenced write on MSSQL"
+      (test-multi-read-cannot-poison-a-fenced-write #(store/connect-store spec {:sync? true})
+                                                    #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_mysql_test.clj
+++ b/test/konserve_jdbc/core_mysql_test.clj
@@ -12,6 +12,8 @@
                                         test-concurrent-create-if-absent
                                         test-duplicate-insert-is-classified
                                         test-comparison-is-byte-exact
+                                        test-enumeration-does-not-break-fenced-writes
+                                        test-multi-read-cannot-poison-a-fenced-write
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -104,7 +106,8 @@
     (testing "Conditional write contract on MySQL"
       (test-conditional-writes #(do (store/delete-store spec {:sync? true})
                                     (store/connect-store spec {:sync? true}))
-                               #(release % {:sync? true})))
+                               #(release % {:sync? true})
+                               :global))
     (store/delete-store spec {:sync? true})))
 
 (deftest jdbc-concurrent-fenced-counter-test
@@ -134,4 +137,21 @@
       (test-concurrent-create-if-absent #(store/connect-store spec {:sync? true})
                                         #(release % {:sync? true})
                                         4))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-enumeration-vs-fenced-write-test
+  (let [spec (assoc db-spec :table "swept_counter_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "A k/keys sweep does not manufacture conflicts on MySQL"
+      (test-enumeration-does-not-break-fenced-writes #(store/connect-store spec {:sync? true})
+                                                     #(release % {:sync? true})
+                                                     150))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-multi-read-poisoning-test
+  (let [spec (assoc db-spec :table "poison_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "A multi-read cannot redirect a fenced write on MySQL"
+      (test-multi-read-cannot-poison-a-fenced-write #(store/connect-store spec {:sync? true})
+                                                    #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_mysql_test.clj
+++ b/test/konserve_jdbc/core_mysql_test.clj
@@ -7,6 +7,11 @@
             [konserve.core :as k]
             [konserve-jdbc.util :refer [test-multi-operations-sync
                                         test-multi-operations-async
+                                        test-conditional-writes
+                                        test-concurrent-fenced-counter
+                                        test-concurrent-create-if-absent
+                                        test-duplicate-insert-is-classified
+                                        test-comparison-is-byte-exact
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -93,3 +98,40 @@
       (test-multi-operations-async store "MySQL" default-num-keys))
     (<!! (release store {:sync? false}))
     (<!! (store/delete-store spec {:sync? false}))))
+(deftest jdbc-conditional-write-test
+  (let [spec (assoc db-spec :table "conditional_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Conditional write contract on MySQL"
+      (test-conditional-writes #(do (store/delete-store spec {:sync? true})
+                                    (store/connect-store spec {:sync? true}))
+                               #(release % {:sync? true})))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-concurrent-fenced-counter-test
+  (let [spec (assoc db-spec :table "fenced_counter_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Concurrent fenced increments on MySQL lose nothing"
+      (test-concurrent-fenced-counter #(store/connect-store spec {:sync? true})
+                                      #(release % {:sync? true})
+                                      4 15))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-fence-mechanism-test
+  (let [spec (assoc db-spec :table "fence_mechanism_test")
+        _ (store/delete-store spec {:sync? true})
+        store (store/connect-store spec {:sync? true})]
+    (testing "The database refuses a duplicate key in a way we can classify (MySQL)"
+      (test-duplicate-insert-is-classified store))
+    (testing "The fenced comparison is byte-exact (MySQL)"
+      (test-comparison-is-byte-exact store))
+    (release store {:sync? true})
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-concurrent-create-if-absent-test
+  (let [spec (assoc db-spec :table "contested_create_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Contested create-if-absent on MySQL has exactly one winner"
+      (test-concurrent-create-if-absent #(store/connect-store spec {:sync? true})
+                                        #(release % {:sync? true})
+                                        4))
+    (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_postgres_test.clj
+++ b/test/konserve_jdbc/core_postgres_test.clj
@@ -12,6 +12,8 @@
                                         test-concurrent-create-if-absent
                                         test-duplicate-insert-is-classified
                                         test-comparison-is-byte-exact
+                                        test-enumeration-does-not-break-fenced-writes
+                                        test-multi-read-cannot-poison-a-fenced-write
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -97,7 +99,8 @@
     (testing "Conditional write contract on Postgres"
       (test-conditional-writes #(do (store/delete-store spec {:sync? true})
                                     (store/connect-store spec {:sync? true}))
-                               #(release % {:sync? true})))
+                               #(release % {:sync? true})
+                               :global))
     (store/delete-store spec {:sync? true})))
 
 (deftest jdbc-concurrent-fenced-counter-test
@@ -127,4 +130,21 @@
       (test-concurrent-create-if-absent #(store/connect-store spec {:sync? true})
                                         #(release % {:sync? true})
                                         4))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-enumeration-vs-fenced-write-test
+  (let [spec (assoc db-spec :table "swept_counter_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "A k/keys sweep does not manufacture conflicts on Postgres"
+      (test-enumeration-does-not-break-fenced-writes #(store/connect-store spec {:sync? true})
+                                                     #(release % {:sync? true})
+                                                     150))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-multi-read-poisoning-test
+  (let [spec (assoc db-spec :table "poison_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "A multi-read cannot redirect a fenced write on Postgres"
+      (test-multi-read-cannot-poison-a-fenced-write #(store/connect-store spec {:sync? true})
+                                                    #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_postgres_test.clj
+++ b/test/konserve_jdbc/core_postgres_test.clj
@@ -7,6 +7,11 @@
             [konserve.store :as store]
             [konserve-jdbc.util :refer [test-multi-operations-sync
                                         test-multi-operations-async
+                                        test-conditional-writes
+                                        test-concurrent-fenced-counter
+                                        test-concurrent-create-if-absent
+                                        test-duplicate-insert-is-classified
+                                        test-comparison-is-byte-exact
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -84,4 +89,42 @@
     (<!! (store/delete-store spec {:sync? false}))))
 (deftest jdbc-read-miss-safe-marker-test
   (testing "JDBC backing implements PReadMissSafe (io-operation skips the -blob-exists? SELECT probe on reads)"
-    (is (satisfies? sl/PReadMissSafe (jc/->JDBCTable nil nil nil)))))
+    (is (satisfies? sl/PReadMissSafe (jc/->JDBCTable nil nil nil nil)))))
+
+(deftest jdbc-conditional-write-test
+  (let [spec (assoc db-spec :table "conditional_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Conditional write contract on Postgres"
+      (test-conditional-writes #(do (store/delete-store spec {:sync? true})
+                                    (store/connect-store spec {:sync? true}))
+                               #(release % {:sync? true})))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-concurrent-fenced-counter-test
+  (let [spec (assoc db-spec :table "fenced_counter_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Concurrent fenced increments on Postgres lose nothing"
+      (test-concurrent-fenced-counter #(store/connect-store spec {:sync? true})
+                                      #(release % {:sync? true})
+                                      4 15))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-fence-mechanism-test
+  (let [spec (assoc db-spec :table "fence_mechanism_test")
+        _ (store/delete-store spec {:sync? true})
+        store (store/connect-store spec {:sync? true})]
+    (testing "The database refuses a duplicate key in a way we can classify (Postgres)"
+      (test-duplicate-insert-is-classified store))
+    (testing "The fenced comparison is byte-exact (Postgres)"
+      (test-comparison-is-byte-exact store))
+    (release store {:sync? true})
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-concurrent-create-if-absent-test
+  (let [spec (assoc db-spec :table "contested_create_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Contested create-if-absent on Postgres has exactly one winner"
+      (test-concurrent-create-if-absent #(store/connect-store spec {:sync? true})
+                                        #(release % {:sync? true})
+                                        4))
+    (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_sql_lite_test.clj
+++ b/test/konserve_jdbc/core_sql_lite_test.clj
@@ -11,6 +11,8 @@
                                         test-concurrent-create-if-absent
                                         test-duplicate-insert-is-classified
                                         test-comparison-is-byte-exact
+                                        test-enumeration-does-not-break-fenced-writes
+                                        test-multi-read-cannot-poison-a-fenced-write
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -64,7 +66,8 @@
     (testing "Conditional write contract on SQLite"
       (test-conditional-writes #(do (store/delete-store spec {:sync? true})
                                     (store/connect-store spec {:sync? true}))
-                               #(release % {:sync? true})))
+                               #(release % {:sync? true})
+                               :machine))
     (store/delete-store spec {:sync? true})))
 
 (deftest jdbc-concurrent-fenced-counter-test
@@ -94,4 +97,21 @@
       (test-concurrent-create-if-absent #(store/connect-store spec {:sync? true})
                                         #(release % {:sync? true})
                                         2))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-enumeration-vs-fenced-write-test
+  (let [spec (assoc db-spec :table "swept_counter_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "A k/keys sweep does not manufacture conflicts on SQLite"
+      (test-enumeration-does-not-break-fenced-writes #(store/connect-store spec {:sync? true})
+                                                     #(release % {:sync? true})
+                                                     150))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-multi-read-poisoning-test
+  (let [spec (assoc db-spec :table "poison_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "A multi-read cannot redirect a fenced write on SQLite"
+      (test-multi-read-cannot-poison-a-fenced-write #(store/connect-store spec {:sync? true})
+                                                    #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_sql_lite_test.clj
+++ b/test/konserve_jdbc/core_sql_lite_test.clj
@@ -6,6 +6,11 @@
             [konserve.store :as store]
             [konserve-jdbc.util :refer [with-dir test-multi-operations-sync
                                         test-multi-operations-async
+                                        test-conditional-writes
+                                        test-concurrent-fenced-counter
+                                        test-concurrent-create-if-absent
+                                        test-duplicate-insert-is-classified
+                                        test-comparison-is-byte-exact
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -52,3 +57,41 @@
       (test-multi-operations-async store "SQLite" default-num-keys))
     (<!! (release store {:sync? false}))
     (<!! (store/delete-store spec {:sync? false}))))
+
+(deftest jdbc-conditional-write-test
+  (let [spec (assoc db-spec :table "conditional_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Conditional write contract on SQLite"
+      (test-conditional-writes #(do (store/delete-store spec {:sync? true})
+                                    (store/connect-store spec {:sync? true}))
+                               #(release % {:sync? true})))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-concurrent-fenced-counter-test
+  (let [spec (assoc db-spec :table "fenced_counter_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Concurrent fenced increments on SQLite lose nothing"
+      (test-concurrent-fenced-counter #(store/connect-store spec {:sync? true})
+                                      #(release % {:sync? true})
+                                      2 10))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-fence-mechanism-test
+  (let [spec (assoc db-spec :table "fence_mechanism_test")
+        _ (store/delete-store spec {:sync? true})
+        store (store/connect-store spec {:sync? true})]
+    (testing "The database refuses a duplicate key in a way we can classify (SQLite)"
+      (test-duplicate-insert-is-classified store))
+    (testing "The fenced comparison is byte-exact (SQLite)"
+      (test-comparison-is-byte-exact store))
+    (release store {:sync? true})
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-concurrent-create-if-absent-test
+  (let [spec (assoc db-spec :table "contested_create_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Contested create-if-absent on SQLite has exactly one winner"
+      (test-concurrent-create-if-absent #(store/connect-store spec {:sync? true})
+                                        #(release % {:sync? true})
+                                        2))
+    (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_sqlserver_test.clj
+++ b/test/konserve_jdbc/core_sqlserver_test.clj
@@ -10,6 +10,8 @@
                                         test-concurrent-create-if-absent
                                         test-duplicate-insert-is-classified
                                         test-comparison-is-byte-exact
+                                        test-enumeration-does-not-break-fenced-writes
+                                        test-multi-read-cannot-poison-a-fenced-write
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -67,7 +69,8 @@
     (testing "Conditional write contract on SQL Server"
       (test-conditional-writes #(do (store/delete-store spec {:sync? true})
                                     (store/connect-store spec {:sync? true}))
-                               #(release % {:sync? true})))
+                               #(release % {:sync? true})
+                               :global))
     (store/delete-store spec {:sync? true})))
 
 (deftest jdbc-fence-mechanism-test
@@ -97,4 +100,21 @@
       (test-concurrent-create-if-absent #(store/connect-store spec {:sync? true})
                                         #(release % {:sync? true})
                                         4))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-enumeration-vs-fenced-write-test
+  (let [spec (assoc db-spec :table "swept_counter_test_ss")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "A k/keys sweep does not manufacture conflicts on SQL Server"
+      (test-enumeration-does-not-break-fenced-writes #(store/connect-store spec {:sync? true})
+                                                     #(release % {:sync? true})
+                                                     150))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-multi-read-poisoning-test
+  (let [spec (assoc db-spec :table "poison_test_ss")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "A multi-read cannot redirect a fenced write on SQL Server"
+      (test-multi-read-cannot-poison-a-fenced-write #(store/connect-store spec {:sync? true})
+                                                    #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_sqlserver_test.clj
+++ b/test/konserve_jdbc/core_sqlserver_test.clj
@@ -5,6 +5,11 @@
             [konserve-jdbc.core :refer [release]]
             [konserve.store :as store]
             [konserve-jdbc.util :refer [test-multi-operations-sync test-multi-operations-async
+                                        test-conditional-writes
+                                        test-concurrent-fenced-counter
+                                        test-concurrent-create-if-absent
+                                        test-duplicate-insert-is-classified
+                                        test-comparison-is-byte-exact
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -52,3 +57,44 @@
       (test-multi-operations-async store "SQL Server" default-num-keys))
     (<!! (release store {:sync? false}))
     (<!! (store/delete-store spec {:sync? false}))))
+
+;; The same server as `core-mssql-test`, reached under the other dbtype name.
+;; Both spellings map to the same statements and the same domain, and this is
+;; where that stays true.
+(deftest jdbc-conditional-write-test
+  (let [spec (assoc db-spec :table "conditional_test_ss")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Conditional write contract on SQL Server"
+      (test-conditional-writes #(do (store/delete-store spec {:sync? true})
+                                    (store/connect-store spec {:sync? true}))
+                               #(release % {:sync? true})))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-fence-mechanism-test
+  (let [spec (assoc db-spec :table "fence_mechanism_test_ss")
+        _ (store/delete-store spec {:sync? true})
+        store (store/connect-store spec {:sync? true})]
+    (testing "The database refuses a duplicate key in a way we can classify (SQL Server)"
+      (test-duplicate-insert-is-classified store))
+    (testing "The fenced comparison is byte-exact (SQL Server)"
+      (test-comparison-is-byte-exact store))
+    (release store {:sync? true})
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-concurrent-fenced-counter-test
+  (let [spec (assoc db-spec :table "fenced_counter_test_ss")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Concurrent fenced increments on SQL Server lose nothing"
+      (test-concurrent-fenced-counter #(store/connect-store spec {:sync? true})
+                                      #(release % {:sync? true})
+                                      4 15))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-concurrent-create-if-absent-test
+  (let [spec (assoc db-spec :table "contested_create_test_ss")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Contested create-if-absent on SQL Server has exactly one winner"
+      (test-concurrent-create-if-absent #(store/connect-store spec {:sync? true})
+                                        #(release % {:sync? true})
+                                        4))
+    (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/util.clj
+++ b/test/konserve_jdbc/util.clj
@@ -1,6 +1,9 @@
 (ns konserve-jdbc.util
   (:require [clojure.java.io :as io]
             [konserve.core :as k]
+            [konserve.compliance-test :as ct]
+            [konserve-jdbc.core :as core]
+            [next.jdbc :as jdbc]
             [clojure.core.async :refer [<!!]]
             [clojure.test :refer [is]])
   (:import  [java.io File]))
@@ -170,3 +173,163 @@
     ;; Verify store is empty
     (let [all-keys (<!! (k/keys store {:sync? false}))]
       (is (zero? (count all-keys))))))
+
+;; ---------------------------------------------------------------------------
+;; Conditional writes
+;; ---------------------------------------------------------------------------
+
+(defn test-conditional-writes
+  "The contract, both ways round.
+
+   Worth saying what this does NOT establish: konserve compares the revision it
+   read against the caller's before it ever reaches the backend, so a backend
+   with no storage-level comparison at all still passes this test
+   single-threaded. It is the shape of the API that is checked here — the
+   refusal, the domain, `absent` — and `test-concurrent-fenced-counter` is what
+   checks that the fence has teeth.
+
+   Each arm gets an EMPTY store, which means dropping the table in between and
+   not merely reconnecting: `conditional-write-compliance-test` already covers
+   sync AND async, so it writes `:cas-async` itself, and the async variant that
+   follows would then find its create-if-absent key already present."
+  [fresh! release!]
+  (let [a (fresh!)]
+    (try (ct/conditional-write-compliance-test a) (finally (release! a))))
+  (let [b (fresh!)]
+    (try (<!! (ct/async-conditional-write-compliance-test b)) (finally (release! b)))))
+
+(defn test-concurrent-fenced-counter
+  "Many writers, one key, no lost update.
+
+   Each writer gets its OWN store — its own connection, and so its own lock
+   registry — because konserve's `go-locked` serialises threads that share one
+   store instance, and a test that shares one would pass with no fence at all.
+   What is left after that is exactly the window the database closes: read the
+   head, be descheduled, write it back over someone else's commit.
+
+   The counter is asserted, not the conflict count: every increment that was
+   told it succeeded must be in the total. A backend that silently overwrites
+   loses some and the sum comes up short."
+  [connect! release! writers per-writer]
+  (let [stores (vec (repeatedly writers connect!))
+        k :fenced-counter
+        _ (k/assoc (first stores) k 0 {:sync? true})
+        committed (atom 0)
+        conflicts (atom 0)
+        run (fn [store]
+              (dotimes [_ per-writer]
+                (loop [attempt 0]
+                  (let [[v rev] (k/get store k nil {:sync? true :with-revision? true})
+                        res (try
+                              (k/assoc store k (inc v) {:sync? true :expected-revision rev})
+                              ::ok
+                              (catch Exception e
+                                (if (= :konserve/revision-mismatch (:type (ex-data e)))
+                                  (do (swap! conflicts inc) ::retry)
+                                  (throw e))))]
+                    (if (= ::ok res)
+                      (swap! committed inc)
+                      (do (Thread/sleep (long (rand-int (min 50 (inc attempt)))))
+                          (recur (inc attempt))))))))]
+    (try
+      (doseq [f (mapv #(future (run %)) stores)] @f)
+      (let [final (k/get (first stores) k nil {:sync? true})]
+        (is (= (* writers per-writer) @committed))
+        (is (= (* writers per-writer) final)
+            (str "lost updates: " (- (* writers per-writer) final)
+                 " of " (* writers per-writer) " committed increments are missing"))
+        (println (format "    %d writers x %d increments -> %d, %d conflicts refused"
+                         writers per-writer final @conflicts)))
+      (finally
+        ;; The pool is keyed by the spec, so these stores share one — closing it
+        ;; twice is not an error worth failing the test over.
+        (doseq [s stores] (try (release! s) (catch Exception _ nil)))))))
+
+(defn- bytes-of [& xs] (byte-array (map unchecked-byte xs)))
+
+(defn test-duplicate-insert-is-classified
+  "The create-if-absent refusal must arrive as a REVISION MISMATCH.
+
+   Not reachable from the public API on demand: konserve reads the key under its
+   lock first, so a create-if-absent onto a key that plainly exists is rejected
+   before any INSERT is sent. The INSERT is refused only when a competitor lands
+   in the gap between that read and the write — a real race, and a rare one to
+   schedule on purpose. So the classifier is checked directly here, because
+   getting it wrong surfaces as a raw driver exception instead of the mismatch
+   the caller is written to retry.
+
+   sqlite is why this test exists: it reports no SQLSTATE at all, so a
+   class-23 check alone passes every other database and drops this one."
+  [store]
+  (let [backing (:backing store)
+        conn (:connection backing)
+        tbl (:table backing)
+        db-type (:dbtype (:db-spec backing))
+        id "duplicate-insert-probe"
+        stmt #(jdbc/execute-one! conn (core/fenced-insert-statement
+                                       db-type tbl id (bytes-of 1) (bytes-of 2) (bytes-of 3)))]
+    (try (jdbc/execute! conn [(str "DELETE FROM " tbl " WHERE id = ?") id]) (catch Exception _ nil))
+    (stmt)
+    (let [e (try (stmt) ::no-refusal (catch java.sql.SQLException e e))]
+      (is (not= ::no-refusal e) "the primary key must refuse the second insert")
+      (is (core/integrity-violation? e)
+          (str "unclassified refusal on " db-type
+               ": sqlstate=" (pr-str (.getSQLState ^java.sql.SQLException e))
+               " code=" (.getErrorCode ^java.sql.SQLException e))))
+    (jdbc/execute! conn [(str "DELETE FROM " tbl " WHERE id = ?") id])))
+
+(defn test-comparison-is-byte-exact
+  "The fenced UPDATE must not match metadata that merely STARTS with what we read.
+
+   SQL Server's varbinary comparison treats trailing zero bytes as
+   insignificant, so `0x010203` compares equal to a stored `0x0102030000` —
+   measured, an UPDATE guarded that way reported one row changed. Serialized
+   metadata ending in a zero byte is ordinary, and the write it would wave
+   through is precisely the overwrite the fence exists to stop. The dialect
+   statement adds a length test there; this checks that it did."
+  [store]
+  (let [backing (:backing store)
+        conn (:connection backing)
+        tbl (:table backing)
+        db-type (:dbtype (:db-spec backing))
+        id "byte-exact-probe"
+        stored (bytes-of 1 2 3 0 0)
+        prefix (bytes-of 1 2 3)]
+    (try (jdbc/execute! conn [(str "DELETE FROM " tbl " WHERE id = ?") id]) (catch Exception _ nil))
+    (jdbc/execute-one! conn (core/fenced-insert-statement db-type tbl id (bytes-of 1) stored (bytes-of 3)))
+    (let [truncated (jdbc/execute-one!
+                     conn (core/fenced-update-statement db-type tbl id (bytes-of 9) (bytes-of 9) (bytes-of 9) prefix))
+          honest (jdbc/execute-one!
+                  conn (core/fenced-update-statement db-type tbl id (bytes-of 1) (bytes-of 8) (bytes-of 3) stored))]
+      (is (zero? (:next.jdbc/update-count truncated 0))
+          (str db-type " matched a truncated prefix of the stored metadata"))
+      (is (= 1 (:next.jdbc/update-count honest 0))
+          (str db-type " refused a write against the metadata actually stored")))
+    (jdbc/execute! conn [(str "DELETE FROM " tbl " WHERE id = ?") id])))
+
+(defn test-concurrent-create-if-absent
+  "One key, many creators, exactly one winner.
+
+   The other half of the fence, and the half with no revision to compare: the
+   losers are refused either by the read konserve takes under its lock or, when
+   they slip past it, by the primary key. Both must arrive as a mismatch."
+  [connect! release! writers]
+  (let [stores (vec (repeatedly writers connect!))
+        k :contested-create
+        winners (atom 0)
+        losers (atom 0)]
+    (try
+      (doseq [f (mapv (fn [s]
+                        (future
+                          (try (k/assoc s k {:by (str s)} {:sync? true :expected-revision k/absent})
+                               (swap! winners inc)
+                               (catch Exception e
+                                 (if (= :konserve/revision-mismatch (:type (ex-data e)))
+                                   (swap! losers inc)
+                                   (throw e))))))
+                      stores)]
+        @f)
+      (is (= 1 @winners) "exactly one create-if-absent may succeed")
+      (is (= (dec writers) @losers) "every other creator must be told it lost")
+      (finally
+        (doseq [s stores] (try (release! s) (catch Exception _ nil)))))))

--- a/test/konserve_jdbc/util.clj
+++ b/test/konserve_jdbc/util.clj
@@ -192,9 +192,19 @@
    not merely reconnecting: `conditional-write-compliance-test` already covers
    sync AND async, so it writes `:cas-async` itself, and the async variant that
    follows would then find its create-if-absent key already present."
-  [fresh! release!]
+  [fresh! release! expected-domain]
   (let [a (fresh!)]
-    (try (ct/conditional-write-compliance-test a) (finally (release! a))))
+    (try
+      ;; Pinned, because the compliance test BRANCHES on the capability: a store
+      ;; that declares none takes the "refuses rather than ignores" arm and passes.
+      ;; Without this line the whole contract test stays green with the fence
+      ;; removed, which is no test at all. It also pins the domain VALUE — a
+      ;; `:global` silently becoming `:machine` is a promise quietly withdrawn.
+      (is (k/conditional-write? a) "the store must declare conditional-write support")
+      (is (= expected-domain (k/conditional-write-domain a)))
+      (is (k/conditional-write? a expected-domain))
+      (ct/conditional-write-compliance-test a)
+      (finally (release! a))))
   (let [b (fresh!)]
     (try (<!! (ct/async-conditional-write-compliance-test b)) (finally (release! b)))))
 
@@ -234,7 +244,15 @@
     (try
       (doseq [f (mapv #(future (run %)) stores)] @f)
       (let [final (k/get (first stores) k nil {:sync? true})]
-        (is (= (* writers per-writer) @committed))
+        ;; NOT asserted: that `committed` reached its target. Every loop iteration
+        ;; increments it exactly once before exiting, so it is true by
+        ;; construction and proves nothing.
+        ;;
+        ;; Asserted instead: that the run was actually contended. Four writers on
+        ;; ONE key produce refusals in the hundreds; a run with none would mean the
+        ;; writers had serialised and the counter agreeing would be worth nothing.
+        (is (pos? @conflicts)
+            "no writer was ever refused, so this run did not exercise the fence")
         (is (= (* writers per-writer) final)
             (str "lost updates: " (- (* writers per-writer) final)
                  " of " (* writers per-writer) " committed increments are missing"))
@@ -333,3 +351,84 @@
       (is (= (dec writers) @losers) "every other creator must be told it lost")
       (finally
         (doseq [s stores] (try (release! s) (catch Exception _ nil)))))))
+
+(defn test-enumeration-does-not-break-fenced-writes
+  "A `k/keys` sweep must not manufacture conflicts.
+
+   `list-keys` opens and closes a row for EVERY key it enumerates, and
+   `konserve.core/keys` takes no lock at all — so anything the backing evicts on
+   close, an enumeration can evict out from under an in-flight conditional write.
+   `konserve.gc/sweep!` runs through exactly this path, which makes a background
+   GC enough to trigger it.
+
+   A SOLE writer, therefore: no competing writer exists, so every rejection this
+   sees is manufactured. Measured before the eviction was gated: 17 of 300."
+  [connect! release! iterations]
+  (let [store (connect!)
+        k :swept-counter
+        sweeping (atom true)
+        spurious (atom 0)]
+    (try
+      (k/assoc store k 0 {:sync? true})
+      (dotimes [i 40] (k/assoc store (keyword (str "filler-" i)) i {:sync? true}))
+      (let [sweeper (future (while @sweeping (k/keys store {:sync? true})))]
+        (try
+          (dotimes [_ iterations]
+            (let [[v rev] (k/get store k nil {:sync? true :with-revision? true})]
+              (try (k/assoc store k (inc v) {:sync? true :expected-revision rev})
+                   (catch Exception e
+                     (if (= :konserve/revision-mismatch (:type (ex-data e)))
+                       (swap! spurious inc)
+                       (throw e))))))
+          (finally (reset! sweeping false) @sweeper)))
+      (is (zero? @spurious)
+          (str @spurious " of " iterations " fenced writes were rejected with no competing writer"))
+      (is (= iterations (k/get store k nil {:sync? true})))
+      (finally (try (release! store) (catch Exception _ nil))))))
+
+(defn test-multi-read-cannot-poison-a-fenced-write
+  "A concurrent multi-read must not decide what a fenced write compares against.
+
+   The backing has to remember the metadata its read saw, because konserve calls
+   `-sync` on a different row than the one it read from. `multi-get` forwards
+   whatever opts it is handed, takes no per-key lock, and never closes its rows —
+   so if any read carrying `:expected-revision` were allowed to deposit, a
+   multi-read could replace an in-flight conditional write's remembered metadata
+   with NEWER metadata, and that write would then compare against the value that
+   overtook it and land on top.
+
+   Deterministic, not a race: the conditional write is parked inside its `up-fn`,
+   which runs after konserve's revision check and before the row is synced."
+  [connect! release!]
+  (let [a (connect!)
+        b (connect!)
+        k :poison-target
+        entered (promise)
+        gate (promise)]
+    (try
+      (k/assoc a k {:v :original} {:sync? true})
+      (let [[_ rev] (k/get a k nil {:sync? true :with-revision? true})
+            writer (future
+                     (try (k/update-in a [k] (fn [v]
+                                               (deliver entered true)
+                                               (deref gate 20000 :timeout)
+                                               (assoc v :v :stale))
+                                       {:sync? true :expected-revision rev})
+                          ::wrote
+                          (catch Exception e (:type (ex-data e) e))))]
+        (deref entered 20000 nil)
+        ;; someone else commits while the fenced write is parked
+        (k/assoc b k {:v :winner} {:sync? true})
+        ;; the poisoning read: same store as the parked write, same key, and it
+        ;; carries the option. Backgrounded with a timeout only so a future
+        ;; konserve that DID take the lock here would not hang the suite.
+        (deref (future (try (k/multi-get a [k] {:sync? true :expected-revision rev})
+                            (catch Exception _ nil)))
+               5000 nil)
+        (deliver gate true)
+        (is (= :konserve/revision-mismatch (deref writer 20000 :never-returned))
+            "the parked write was derived from metadata that has since been replaced")
+        (is (= {:v :winner} (k/get a k nil {:sync? true}))
+            "the value that committed in between must survive"))
+      (finally
+        (doseq [s [a b]] (try (release! s) (catch Exception _ nil)))))))


### PR DESCRIPTION
Adds `:expected-revision` support to konserve-jdbc, the JDBC leg of the conditional-write vertical (konserve `0.9.376`, already released; s3, gcs, dynamodb, redis, indexeddb, lmdb and rocksdb landed before this).

## The write

One statement:

```sql
UPDATE konserve SET header = ?, meta = ?, val = ? WHERE id = ? AND meta = ?
```

The comparison and the write are the same step and the database evaluates it, so the backing declares `PSelfConditionalWrite` — konserve adds no sidecar and no lock of its own. Create-if-absent is a plain `INSERT` refused by the primary key.

No version column and **no schema change**: konserve's revision lives inside the serialized metadata, so for a row the meta bytes *are* the revision. Existing tables work unchanged.

`-sync` runs on a different `JDBCRow` than the read did, so the read remembers the metadata it saw — only when the operation carries `:expected-revision`, and only until the row it read from is closed. A missing entry means no read happened, which for a fenced write is create-if-absent; if an entry ever went missing for another reason the write becomes an INSERT the primary key refuses. That is the direction to fail in — the alternative, treating a missing entry as permission to overwrite, is the silent loss the fence exists to prevent.

## The domain

Follows the database, not the mechanism:

| `:dbtype` | Domain |
|---|---|
| `postgresql`, `yugabytedb`, `mysql`, `mssql`, `sqlserver` | `:global` |
| `sqlite`, `h2` (file) | `:machine` |
| `h2:mem` | `:process` |

Anything else gets **no** domain, and `:expected-revision` is refused rather than quietly ignored.

## Two dialect details, measured rather than assumed

**SQL Server ignores trailing zero bytes** in `varbinary` comparison. Probed against the running container: a stored `0x0102030000` compares equal to `0x010203` and the guarded UPDATE reported one row changed — a stale write waved through, on metadata that happens to end in a zero byte, which is ordinary. The mssql/sqlserver statement tests `DATALENGTH` too. Postgres `bytea`, MySQL `longblob` and SQLite BLOBs are exact.

**SQLite reports a duplicate key with no SQLSTATE at all**, carrying the refusal in vendor code 19. A class-23 check alone passes every other database and drops that one, turning a clean rejection into a raw driver exception the caller cannot classify.

Also verified while there: MySQL's JDBC driver returns *matched* rows, not changed rows, so rewriting identical metadata does not read as a refusal.

## Tests

Per dialect — postgres, mysql, mssql, sqlserver, h2, sqlite — the konserve contract (sync and async arms, each on an empty table), plus four that the contract alone cannot establish:

- **concurrent fenced counter** — writers on separate store instances, since `go-locked` serialises threads sharing one store and a test that shares one would pass with no fence at all
- **contested create-if-absent** — exactly one winner, every loser told
- **duplicate insert is classified** — the SQLite case, direct, because the INSERT refusal is only reachable through a real race
- **comparison is byte-exact** — the SQL Server case

Negative controls run on all three mechanisms; each goes red when its handling is removed. Without the guarded UPDATE, four writers doing fifteen fenced increments each lose **33 of 60**.

Full suite: `54 tests, 2811 assertions, 0 failures` against postgres, mysql and mssql in Docker plus h2 and sqlite on disk. clj-kondo warning count unchanged; cljfmt clean.