### PR TITLE
konserve 0.9.378, and a test that can still fail after it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable, user-visible changes to konserve-jdbc are documented here.
   The domain follows the database: `:global` for PostgreSQL, YugabyteDB, MySQL and
   SQL Server, `:machine` for SQLite and file-based H2, `:process` for in-memory H2.
   A `:dbtype` outside that set gets no domain and `:expected-revision` is refused
-  rather than ignored. Requires konserve `0.9.376`+.
+  rather than ignored. Requires konserve `0.9.378`+.
 
   Two dialect details, both measured rather than assumed: SQL Server's `varbinary`
   comparison ignores trailing zero bytes, so the statement compares `DATALENGTH`
@@ -38,6 +38,11 @@ All notable, user-visible changes to konserve-jdbc are documented here.
   Requires konserve `0.9.354`+.
 
 ### Changed
+- konserve `0.9.376` → `0.9.378`, which refuses `:expected-revision` on
+  `multi-get` and `multi-dissoc` centrally (konserve#175) and revokes a
+  self-fenced domain under `:in-place? false` (konserve#176) — both of which this
+  backend already defended locally. The local defences stay: a backing should not
+  depend on the library above it for a property it can enforce itself.
 - **`:config {:in-place? false}` is now refused at connect time.** It never worked
   on this backend — the layout renames `<key>.new` over `<key>`, but a rename is
   `UPDATE ... SET id = ?` and the primary key refuses it whenever the destination
@@ -47,4 +52,4 @@ All notable, user-visible changes to konserve-jdbc are documented here.
   conditional-write read cache). Code that constructs the record directly rather
   than through `connect-store` needs updating; `connect-store` itself is
   unchanged.
-- konserve `0.9.342` → `0.9.376`.
+- konserve `0.9.342` → `0.9.378`.

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.replikativ/logging {:mvn/version "0.1.3"}
-        org.replikativ/konserve {:mvn/version "0.9.376"}
+        org.replikativ/konserve {:mvn/version "0.9.378"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.11.1"}
         com.github.seancorfield/next.jdbc {:mvn/version "1.3.874"}

--- a/test/konserve_jdbc/core_h2_test.clj
+++ b/test/konserve_jdbc/core_h2_test.clj
@@ -13,6 +13,7 @@
                                         test-comparison-is-byte-exact
                                         test-enumeration-does-not-break-fenced-writes
                                         test-multi-read-cannot-poison-a-fenced-write
+                                        test-only-a-fenced-write-deposits
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -116,4 +117,12 @@
     (testing "A multi-read cannot redirect a fenced write on H2"
       (test-multi-read-cannot-poison-a-fenced-write #(store/connect-store spec {:sync? true})
                                                     #(release % {:sync? true})))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-deposit-gate-test
+  (let [spec (assoc db-spec :table "deposit_gate_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Only a conditional write's own read deposits metadata on H2"
+      (test-only-a-fenced-write-deposits #(store/connect-store spec {:sync? true})
+                                         #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_mssql_test.clj
+++ b/test/konserve_jdbc/core_mssql_test.clj
@@ -12,6 +12,7 @@
                                         test-comparison-is-byte-exact
                                         test-enumeration-does-not-break-fenced-writes
                                         test-multi-read-cannot-poison-a-fenced-write
+                                        test-only-a-fenced-write-deposits
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -114,4 +115,12 @@
     (testing "A multi-read cannot redirect a fenced write on MSSQL"
       (test-multi-read-cannot-poison-a-fenced-write #(store/connect-store spec {:sync? true})
                                                     #(release % {:sync? true})))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-deposit-gate-test
+  (let [spec (assoc db-spec :table "deposit_gate_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Only a conditional write's own read deposits metadata on MSSQL"
+      (test-only-a-fenced-write-deposits #(store/connect-store spec {:sync? true})
+                                         #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_mysql_test.clj
+++ b/test/konserve_jdbc/core_mysql_test.clj
@@ -14,6 +14,7 @@
                                         test-comparison-is-byte-exact
                                         test-enumeration-does-not-break-fenced-writes
                                         test-multi-read-cannot-poison-a-fenced-write
+                                        test-only-a-fenced-write-deposits
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -154,4 +155,12 @@
     (testing "A multi-read cannot redirect a fenced write on MySQL"
       (test-multi-read-cannot-poison-a-fenced-write #(store/connect-store spec {:sync? true})
                                                     #(release % {:sync? true})))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-deposit-gate-test
+  (let [spec (assoc db-spec :table "deposit_gate_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Only a conditional write's own read deposits metadata on MySQL"
+      (test-only-a-fenced-write-deposits #(store/connect-store spec {:sync? true})
+                                         #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_postgres_test.clj
+++ b/test/konserve_jdbc/core_postgres_test.clj
@@ -14,6 +14,7 @@
                                         test-comparison-is-byte-exact
                                         test-enumeration-does-not-break-fenced-writes
                                         test-multi-read-cannot-poison-a-fenced-write
+                                        test-only-a-fenced-write-deposits
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -147,4 +148,12 @@
     (testing "A multi-read cannot redirect a fenced write on Postgres"
       (test-multi-read-cannot-poison-a-fenced-write #(store/connect-store spec {:sync? true})
                                                     #(release % {:sync? true})))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-deposit-gate-test
+  (let [spec (assoc db-spec :table "deposit_gate_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Only a conditional write's own read deposits metadata on Postgres"
+      (test-only-a-fenced-write-deposits #(store/connect-store spec {:sync? true})
+                                         #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_sql_lite_test.clj
+++ b/test/konserve_jdbc/core_sql_lite_test.clj
@@ -13,6 +13,7 @@
                                         test-comparison-is-byte-exact
                                         test-enumeration-does-not-break-fenced-writes
                                         test-multi-read-cannot-poison-a-fenced-write
+                                        test-only-a-fenced-write-deposits
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -114,4 +115,12 @@
     (testing "A multi-read cannot redirect a fenced write on SQLite"
       (test-multi-read-cannot-poison-a-fenced-write #(store/connect-store spec {:sync? true})
                                                     #(release % {:sync? true})))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-deposit-gate-test
+  (let [spec (assoc db-spec :table "deposit_gate_test")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Only a conditional write's own read deposits metadata on SQLite"
+      (test-only-a-fenced-write-deposits #(store/connect-store spec {:sync? true})
+                                         #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/core_sqlserver_test.clj
+++ b/test/konserve_jdbc/core_sqlserver_test.clj
@@ -12,6 +12,7 @@
                                         test-comparison-is-byte-exact
                                         test-enumeration-does-not-break-fenced-writes
                                         test-multi-read-cannot-poison-a-fenced-write
+                                        test-only-a-fenced-write-deposits
                                         default-num-keys]])
   (:import [java.util UUID]))
 
@@ -117,4 +118,12 @@
     (testing "A multi-read cannot redirect a fenced write on SQL Server"
       (test-multi-read-cannot-poison-a-fenced-write #(store/connect-store spec {:sync? true})
                                                     #(release % {:sync? true})))
+    (store/delete-store spec {:sync? true})))
+
+(deftest jdbc-deposit-gate-test
+  (let [spec (assoc db-spec :table "deposit_gate_test_ss")
+        _ (store/delete-store spec {:sync? true})]
+    (testing "Only a conditional write's own read deposits metadata on SQL Server"
+      (test-only-a-fenced-write-deposits #(store/connect-store spec {:sync? true})
+                                         #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))

--- a/test/konserve_jdbc/util.clj
+++ b/test/konserve_jdbc/util.clj
@@ -4,6 +4,8 @@
             [konserve.compliance-test :as ct]
             [konserve-jdbc.core :as core]
             [next.jdbc :as jdbc]
+            [next.jdbc.result-set :as rs]
+            [konserve.impl.storage-layout :as sl]
             [clojure.core.async :refer [<!!]]
             [clojure.test :refer [is]])
   (:import  [java.io File]))
@@ -398,7 +400,14 @@
    overtook it and land on top.
 
    Deterministic, not a race: the conditional write is parked inside its `up-fn`,
-   which runs after konserve's revision check and before the row is synced."
+   which runs after konserve's revision check and before the row is synced.
+
+   SCOPE, since it changed: konserve 0.9.377 refuses `:expected-revision` on
+   `multi-get` itself (konserve#175), so on that version and later this exercises
+   the pair — and it passes even with the backing's own gate removed, which is
+   measured, not assumed. What still proves the gate is
+   `test-only-a-fenced-write-deposits`. This one is kept because two independent
+   refusals are the point: the backing must not depend on konserve's."
   [connect! release!]
   (let [a (connect!)
         b (connect!)
@@ -432,3 +441,39 @@
             "the value that committed in between must survive"))
       (finally
         (doseq [s [a b]] (try (release! s) (catch Exception _ nil)))))))
+
+(defn test-only-a-fenced-write-deposits
+  "The backing's own gate, driven directly.
+
+   The metadata a conditional write compares against is remembered by the read
+   konserve takes under the lock. Which reads may deposit is the whole safety
+   property: a read that is not part of a conditional write must leave nothing
+   behind, or some later write consumes it and compares against the wrong bytes.
+
+   Driven at the protocol level rather than through `k/multi-get`, because
+   konserve now refuses that option on reads before the backing ever sees it
+   (konserve#175) — so the end-to-end route can no longer reach this code, and a
+   test that goes through it would pass with the gate deleted. The second
+   assertion is what keeps this one honest: the same call with a WRITE operation
+   must deposit, proving the path being exercised is the real one."
+  [connect! release!]
+  (let [store (connect!)
+        backing (:backing store)]
+    (try
+      (k/assoc store :deposit-probe {:v 1} {:sync? true})
+      (let [store-key (-> (jdbc/execute! (:connection backing)
+                                         [(str "SELECT id FROM " (:table backing))]
+                                         {:builder-fn rs/as-unqualified-lower-maps})
+                          first
+                          :id)
+            deposits (fn [env]
+                       (reset! (:read-cache backing) {})
+                       (let [blob (sl/-create-blob backing store-key env)]
+                         (sl/-read-header blob env)
+                         @(:read-cache backing)))]
+        (is (some? store-key) "the probe row must exist for this to test anything")
+        (is (empty? (deposits {:sync? true :expected-revision :x :operation :read-edn}))
+            "a READ carrying the option must leave nothing for a later write to consume")
+        (is (seq (deposits {:sync? true :expected-revision :x :operation :write-edn}))
+            "and the read belonging to a conditional WRITE must deposit, or the fence has nothing to compare"))
+      (finally (try (release! store) (catch Exception _ nil))))))


### PR DESCRIPTION
Bumps konserve `0.9.376` → `0.9.378`, which carries the two central refusals this backend prompted: replikativ/konserve#175 (`multi-get` / `multi-dissoc` refuse `:expected-revision`) and #176 (a self-fenced domain is revoked under `:in-place? false`).

Both were already defended locally here, and **the local defences stay** — a backing should not depend on the library above it for a property it can enforce itself.

### One consequence, acted on rather than noted

`test-multi-read-cannot-poison-a-fenced-write` drove the hole through `k/multi-get`. konserve now refuses that option before the backing ever sees it, so **the test passes with the backing's own gate deleted**. Measured, not assumed: I removed the gate, ran it against 0.9.378, and it went green.

So the gate gets a test that reaches it, at the protocol level — create a blob, read its header with an env carrying `:expected-revision` and a *read* operation, require that nothing is deposited:

```clojure
(is (empty? (deposits {:sync? true :expected-revision :x :operation :read-edn})))
(is (seq    (deposits {:sync? true :expected-revision :x :operation :write-edn})))
```

The second assertion is what keeps the first honest: without it the test would pass against a backing that never deposits at all, in which case the fence would have nothing to compare. Negative control: with the gate removed it fails on the first assertion.

The end-to-end test stays and its docstring now states its reduced scope. It no longer proves the gate; it proves the two refusals hold together, which is the reason for having both.

**Suite: 72 tests, 2895 assertions, 0 failures** across Postgres, MySQL, MSSQL, SQL Server, H2 and SQLite. clj-kondo warning count unchanged; cljfmt clean.