### PR TITLE
Reference count JDBC connection pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,36 @@ All notable, user-visible changes to konserve-jdbc are documented here.
   marker the redundant `-blob-exists?` SELECT probe is dropped, so a read is one
   SELECT, and read-modify-write ops (`update-in` / `assoc-in` / `bassoc`) skip it too.
   Requires konserve `0.9.354`+.
+- **Pool introspection and recovery.** `pool-status` returns a credential-free
+  snapshot of the pool registry (`:refs`, `:open?`, `:db-spec`). `remove-from-pool`
+  now forgets a pool *without* closing it, so the next `connect-store` builds a
+  fresh one while live stores keep working, and `:validate-pool? true` in the store
+  config makes `connect-store` probe an existing pool and rebuild it if something
+  closed it out of band. `release-pool!` is the spec-level counterpart of `release`.
+
+### Fixed
+- **Releasing one store no longer closes the pool every other store is using.**
+  Pools are keyed by connection, not by table, so every store on a database shares
+  one — but `release` closed that pool outright, leaving every co-tenant holding a
+  dead DataSource. Reported downstream, where datahike's `create-database` /
+  `delete-database` release their store when finished and took every other tenant
+  on the server down with them. Pools are now reference counted: `connect-store`
+  takes a reference, `release` gives one back, and the pool closes when the last
+  holder lets go. `release` is idempotent per store and returns `:closed`,
+  `:retained`, `:already-released` or `:absent`; `{:force? true}` restores the old
+  unconditional close for process shutdown. A connect that fails after taking
+  its reference (a bad table name, a privilege error) hands the reference back,
+  and a store whose pool was closed out of band and rebuilt releases as `:stale`
+  rather than closing the pool the new holders are using.
+- **Leaked JVM shutdown hooks.** Every pool registered a shutdown hook that was
+  never removed, so each connect/release cycle leaked a hook thread and kept a
+  closed DataSource reachable. Hooks are now removed when the pool is closed.
+- **`delete-store` on a `:jdbcUrl`-only config used the wrong dialect.** It built
+  its backing from the raw spec, so the `postgres` → `postgresql` normalisation in
+  `prepare-spec` never reached the DROP statement.
+- **`-delete-store` no longer closes a pooled DataSource.** It closed whatever
+  connection the backing held, which is a `ClassCastException` on a pool and would
+  have shut every other tenant out; it now closes only a connection it owns.
 
 ### Changed
 - konserve `0.9.376` → `0.9.378`, which refuses `:expected-revision` on
@@ -53,3 +83,14 @@ All notable, user-visible changes to konserve-jdbc are documented here.
   than through `connect-store` needs updating; `connect-store` itself is
   unchanged.
 - konserve `0.9.342` → `0.9.378`.
+- Pool creation happens behind a per-database delay and outside the registry lock,
+  so a thousand tenants connecting concurrently no longer serialise behind one JDBC
+  handshake. c3p0 sizing keys (`:maxPoolSize`, `:checkoutTimeout`, …) passed in the
+  store config are applied when the pool is built; they are not part of the pool
+  key, so the first store to reach a database sets them and a later store asking for
+  different values is logged and ignored.
+- `:sync?` is no longer part of the pool key. It never affected the pool itself,
+  and keying on it gave one database two pools as soon as sync and async stores
+  were mixed, and made `release-pool!` / `remove-from-pool` miss the pool when
+  handed the caller's own spec. Per-store lifecycle state rides in `JDBCTable`'s
+  metadata rather than a further positional field.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Operations exceeding batch limits are **automatically batched** within a single 
 
 - All operations are wrapped in JDBC transactions for atomicity (all-or-nothing)
 - Uses bulk INSERT/UPSERT statements for efficient writes
-- Connection pooling via c3p0 is used by default for concurrent access
+- Connection pooling via c3p0 is used by default for concurrent access; pools are shared per database and reference counted (see [Connection Pools and Multi-tenancy](#connection-pools-and-multi-tenancy))
 - Database-specific SQL syntax is handled automatically (MERGE, ON CONFLICT, REPLACE, etc.)
 
 (def store-a (k/create-store store-a-config {:sync? true}))
@@ -279,6 +279,50 @@ there unreliable.
   than a surprise.
 - **`:jdbcUrl` with H2 does not work** (pre-existing): `connection/uri->db-spec`
   returns no `:dbtype` for `jdbc:h2:` URLs. Use `:dbtype "h2"` with `:dbname`.
+
+## Connection Pools and Multi-tenancy
+
+Pools are keyed by **connection**, not by table: every store on the same
+database — every tenant, whatever its `:table` — shares one c3p0 pool. A
+thousand tenants on one Postgres means one pool, not a thousand.
+
+Because the pool is shared, it is reference counted. `connect-store` takes a
+reference, `release` gives one back, and the pool is closed only when the last
+store using it has been released:
+
+```clojure
+(require '[konserve-jdbc.core :as kjdbc])
+
+(def a (k/connect-store (assoc config :table "tenant_a") {:sync? true}))
+(def b (k/connect-store (assoc config :table "tenant_b") {:sync? true}))
+
+(kjdbc/release a {:sync? true})   ;=> :retained  -- b still holds the pool
+(kjdbc/release a {:sync? true})   ;=> :already-released
+(kjdbc/release b {:sync? true})   ;=> :closed
+```
+
+`release` returns `:closed`, `:retained`, `:already-released`, `:absent` or
+`:stale` (the pool this store was opened against was closed out of band and
+rebuilt; nothing is closed), and is idempotent per store. `{:force? true}` in the options closes the shared pool
+regardless of who else is using it — the pre-refcount behaviour, appropriate at
+process shutdown and nowhere else. `delete-store` uses a connection of its own,
+so dropping one tenant's table never disturbs another's store.
+
+**Pool sizing.** c3p0 setters can be passed in the store config and are applied
+when the pool is built: `:maxPoolSize`, `:minPoolSize`, `:initialPoolSize`,
+`:acquireIncrement`, `:checkoutTimeout`, `:maxIdleTime`, `:maxStatements`,
+`:numHelperThreads`. They are not part of the pool key, so the first store to
+reach a database sets them for everyone sharing it; a later store asking for
+different values is logged and ignored. Set `:checkoutTimeout` — c3p0's default
+of `0` waits for a connection forever.
+
+**Introspection and recovery.** `(konserve-jdbc.core/pool-status)` returns a
+credential-free snapshot of the registry (`:refs`, `:open?`, `:db-spec`).
+`remove-from-pool` forgets a pool without closing it, so the next
+`connect-store` builds a fresh one while existing stores keep working; passing
+`:validate-pool? true` in the config makes `connect-store` probe an existing
+pool and rebuild it if something closed it out of band, at the cost of one
+connection checkout per connect.
 
 ## Supported Databases
 

--- a/deps.edn
+++ b/deps.edn
@@ -12,7 +12,13 @@
                               org.apache.derby/derby {:mvn/version "10.16.1.1"}
                               org.postgresql/postgresql {:mvn/version "42.6.0"}
                               org.xerial/sqlite-jdbc {:mvn/version "3.41.2.2"}}}
-           :test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.83.1314"}}
+           :test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.83.1314"}
+                               ;; downstream consumer, for the multi-tenant test:
+                               ;; datahike's create-database/delete-database
+                               ;; release their store when done, which is what
+                               ;; used to close the pool under every other tenant
+                               org.replikativ/datahike {:mvn/version "0.8.1790"
+                                                        :exclusions [org.replikativ/konserve]}}
                   :extra-paths ["test"]
                   #_#_:main-opts ["-m" "kaocha.runner"]}
            :format {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.2"}}

--- a/src/konserve_jdbc/core.clj
+++ b/src/konserve_jdbc/core.clj
@@ -27,30 +27,238 @@
 (def ^:const dbtypes ["h2" "h2:mem" "hsqldb" "jtds:sqlserver" "mysql" "oracle:oci" "oracle:thin" "postgresql" "redshift" "sqlite" "sqlserver" "mssql" "yugabytedb"])
 (def ^:const supported-dbtypes #{"h2" "mysql" "postgresql" "sqlite" "sqlserver" "mssql" "yugabytedb"})
 
-;; this is the link to the various connection pools
-(defonce pool (atom nil))
+;; ---------------------------------------------------------------------------
+;; Connection pools
+;;
+;; One c3p0 pool per unique connection spec, shared by every store that speaks
+;; to that database. The pool key deliberately ignores `:table`: two stores on
+;; two tables of the same database should share connections, and a
+;; store-per-tenant deployment would otherwise open a pool per tenant -- a
+;; thousand tenants would mean a thousand pools and (at c3p0's default
+;; `minPoolSize` of 3) three thousand idle connections against a server whose
+;; default `max_connections` is 100.
+;;
+;; Sharing means the pool cannot belong to any single store, so it is reference
+;; counted. `connect-store` (via `get-connection`) takes a reference and
+;; `release` gives one back; the DataSource is only closed when the last holder
+;; lets go. Before this, `release` closed the pool outright and every other
+;; store on the same database was left holding a dead DataSource -- a
+;; `delete-store` (or datahike's `create-database`/`delete-database`, which
+;; release the store when done) on one tenant took every other tenant on that
+;; server down with it.
+;;
+;; Two things deliberately happen *outside* the registry lock, because both can
+;; block for a long time and would otherwise serialise every connecting thread:
+;; building a pool (a real JDBC handshake -- hence the per-key delay) and
+;; probing one for liveness (a checkout, which on an exhausted pool with c3p0's
+;; default `checkoutTimeout` of 0 waits forever -- hence opt-in).
+;; ---------------------------------------------------------------------------
 
-;; each unique spec will have its own pool
+;; pool key -> {:pool (delay {:datasource ds :hook thread}) :refs n :db-spec spec}
+(defonce pool (atom {}))
+
+;; Guards registry mutation only: map lookups and refcount arithmetic, never a
+;; database round trip.
+(defonce ^:private pool-lock (Object.))
+
+;; c3p0 sizing knobs are not part of the pool key, so the first store to reach a
+;; database decides them for everyone sharing it. We warn when a later spec
+;; disagrees rather than silently ignoring it.
+(def ^:private pool-config-keys
+  [:maxPoolSize :minPoolSize :initialPoolSize :acquireIncrement
+   :checkoutTimeout :maxIdleTime :maxStatements :numHelperThreads])
+
+;; Each unique connection will have its own pool. `:sync?` is deliberately not
+;; part of the key: it changes nothing about how c3p0 talks to the database, and
+;; keying on it gave one database two pools as soon as a caller mixed sync and
+;; async stores -- and made `release-pool!`/`remove-from-pool` miss the pool
+;; when handed the caller's own spec, which `connect-store` never saw with
+;; `:sync?` on it.
 (defn- pool-key [db-spec]
   (keyword
-   (str (hasch/uuid  (select-keys db-spec [:dbtype :jdbcUrl :host :port :user :password :dbname :sync?])))))
+   (str (hasch/uuid  (select-keys db-spec [:dbtype :jdbcUrl :host :port :user :password :dbname])))))
 
-(defn get-connection [db-spec]
+(defn- build-pool
+  "Open a c3p0 pool for `db-spec`. Called at most once per registry entry, from
+   inside the entry's delay."
+  [db-spec]
+  (let [ds ^PooledDataSource (connection/->pool ComboPooledDataSource db-spec)
+        hook (Thread. ^Runnable (fn [] (.close ds)))]
+    ;; fail fast on a bad spec rather than at first use
+    (.close (jdbc/get-connection ds))
+    (.addShutdownHook (Runtime/getRuntime) hook)
+    {:datasource ds :hook hook}))
+
+(defn- close-pool-entry!
+  "Close the DataSource behind a registry entry and drop its shutdown hook.
+   Never forces an unrealized delay: a pool that was never built has nothing to
+   close."
+  [{:keys [pool] :as _entry}]
+  (when (and pool (realized? pool))
+    (let [{:keys [^PooledDataSource datasource ^Thread hook]} @pool]
+      (when hook
+        (try
+          (.removeShutdownHook (Runtime/getRuntime) hook)
+          ;; the JVM is already shutting down; the hook is running or about to
+          (catch IllegalStateException _e nil)))
+      (when datasource
+        (try
+          (.close datasource)
+          (catch Exception e
+            (log/warn :konserve.jdbc/pool-close-failed {:error e})))))))
+
+(defn- pool-alive?
+  "Liveness probe: check a connection out of the pool and hand it straight back.
+   A pool closed out of band (a shutdown hook, a `release` with `:force?`, an
+   older konserve-jdbc closing it under us) throws here. Runs outside
+   `pool-lock` -- a checkout can block."
+  [^PooledDataSource ds]
+  (try
+    (.close (jdbc/get-connection ds))
+    true
+    (catch Exception _e false)))
+
+(defn- warn-on-config-drift! [id existing-spec db-spec]
+  (let [drift (into {}
+                    (keep (fn [k]
+                            (let [want (get db-spec k)
+                                  have (get existing-spec k)]
+                              (when (and (some? want) (not= want have))
+                                [k {:requested want :in-use have}]))))
+                    pool-config-keys)]
+    (when (seq drift)
+      (log/warn :konserve.jdbc/pool-config-ignored
+                {:pool id
+                 :ignored drift
+                 :reason "pool already open; sizing is set by the first store to connect"}))))
+
+(defn- take-reference!
+  "Install a registry entry for `db-spec` if there is none and add one reference
+   to it. Returns the entry; the caller derefs its `:pool` outside the lock."
+  [id db-spec]
+  (locking pool-lock
+    (let [existing (get @pool id)
+          ;; recorded for diagnostics and drift warnings: no credentials, and
+          ;; nothing store-specific -- the pool is shared across tables and
+          ;; sync/async stores alike, so the first connector's `:table` or
+          ;; `:sync?` would be misleading in `pool-status`
+          entry (or existing {:pool (delay (build-pool db-spec))
+                              :refs 0
+                              :db-spec (dissoc db-spec :password :table :sync?)})]
+      (when existing
+        (warn-on-config-drift! id (:db-spec existing) db-spec))
+      (let [entry (update entry :refs inc)]
+        (swap! pool assoc id entry)
+        entry))))
+
+(defn- drop-reference!
+  "Undo a `take-reference!` whose pool failed to build, so one bad spec does not
+   poison the key for later callers. The entry is forgotten outright, whatever
+   its count: a delay that threw will throw for every holder, so none of them
+   has a pool to give back and each will drop the same entry on its way out."
+  [id entry]
+  (locking pool-lock
+    (when (identical? (:pool (get @pool id)) (:pool entry))
+      (swap! pool dissoc id))))
+
+(defn- acquire-pool
+  "Like `get-connection`, but returns `[datasource pool-token]`. The token
+   identifies the registry entry the reference was taken against, so a later
+   release can tell whether it still refers to the same pool (see `release`)."
+  ([db-spec] (acquire-pool db-spec 0))
+  ([db-spec attempt]
+   (let [id (pool-key db-spec)
+         entry (take-reference! id db-spec)
+         {:keys [datasource]} (try
+                                @(:pool entry)
+                                (catch Throwable t
+                                  (drop-reference! id entry)
+                                  (throw t)))]
+     (if (or (not (:validate-pool? db-spec))
+             (pool-alive? datasource))
+       [datasource (:pool entry)]
+       ;; The pool was closed under us. Drop the dead entry -- other holders are
+       ;; holding the same dead DataSource -- and build a fresh one. One retry:
+       ;; a pool that dies twice in a row is a broken database, not a stale
+       ;; registry, and the caller should see that error rather than spin.
+       (do
+         (log/warn :konserve.jdbc/pool-closed-out-of-band
+                   {:pool id :refs (:refs entry) :attempt attempt})
+         (locking pool-lock
+           (when (identical? (:pool (get @pool id)) (:pool entry))
+             (swap! pool dissoc id)))
+         (close-pool-entry! entry)
+         (if (zero? attempt)
+           (recur db-spec (inc attempt))
+           [datasource (:pool entry)]))))))
+
+(defn get-connection
+  "Return the pooled DataSource for `db-spec`, opening it if needed, and take a
+   reference to it. Every call must be paired with a `release` (or
+   `release-pool!`), or the pool is never closed.
+
+   With `:validate-pool? true` in the spec, an already-open pool is probed
+   before it is handed out and rebuilt if it has been closed out of band. The
+   probe costs a connection checkout per connect, so it is off by default."
+  [db-spec]
+  (first (acquire-pool db-spec)))
+
+(defn release-pool!
+  "Give back one reference to the pool for `db-spec`. Closes and forgets the
+   pool when the last reference goes. Returns `:closed`, `:retained` or
+   `:absent`.
+
+   `:force? true` closes the pool no matter how many stores still hold it. That
+   is the old, unconditional behaviour -- a footgun on a shared database, and
+   only appropriate when shutting the whole process down.
+
+   `:token` is the token `acquire-pool` handed out with the reference. When it is
+   given and the registry now holds a *different* pool under this key (the one
+   the reference was taken against was closed out of band and rebuilt), the
+   reference is stale: nothing is decremented and `:stale` is returned, so an
+   old holder cannot close the pool the new holders are using."
+  [db-spec & {:keys [force? token]}]
   (let [id (pool-key db-spec)
-        conn (get @pool id)]
-    (if-not (nil? conn)
-      conn
-      (let [conns ^PooledDataSource (connection/->pool ComboPooledDataSource db-spec)
-            shutdown (fn [] (.close ^PooledDataSource conns))]
-        (swap! pool assoc id conns)
-        (.close (jdbc/get-connection conns))
-        (.addShutdownHook (Runtime/getRuntime)
-                          (Thread. ^Runnable shutdown))
-        conns))))
+        [result entry]
+        (locking pool-lock
+          (let [entry (get @pool id)]
+            (cond
+              (nil? entry) [:absent nil]
 
-(defn remove-from-pool [db-spec]
-  (let [id (pool-key db-spec)]
-    (swap! pool dissoc id)))
+              (and token (not (identical? token (:pool entry)))) [:stale nil]
+
+              (or force? (<= (:refs entry) 1))
+              (do (swap! pool dissoc id)
+                  [:closed entry])
+
+              :else
+              (do (swap! pool update-in [id :refs] dec)
+                  [:retained nil]))))]
+    ;; closing can block, so it happens after the lock is dropped
+    (when entry (close-pool-entry! entry))
+    result))
+
+(defn remove-from-pool
+  "Forget the pool for `db-spec` without closing it, so the next `connect-store`
+   builds a fresh one. Stores that already hold the old DataSource keep working
+   off it; this is the recovery hatch for a pool that has gone bad. The
+   forgotten pool keeps its JVM shutdown hook, so it is still closed at exit."
+  [db-spec]
+  (locking pool-lock
+    (swap! pool dissoc (pool-key db-spec))
+    nil))
+
+(defn pool-status
+  "Registry snapshot for diagnostics and tests: pool key -> {:refs n :open? bool
+   :db-spec spec}, with credentials stripped. Never returns the DataSource
+   itself."
+  []
+  (into {}
+        (map (fn [[id {:keys [refs db-spec] :as entry}]]
+               [id {:refs refs
+                    :open? (boolean (some-> (:pool entry) realized?))
+                    :db-spec db-spec}]))
+        @pool))
 
 (defn extract-bytes [obj dbtype]
   (when obj
@@ -525,6 +733,12 @@
       "sqlite" (if (str/starts-with? name* ":memory:") :process :machine)
       (get server-conditional-write-domains dbtype))))
 
+;; Per-store lifecycle state lives in the record's *metadata* under `:state`,
+;; not in a further field. The atom carries `:released?` -- so a second
+;; `release` of the same store cannot hand back a reference it no longer
+;; holds -- and `:pool`, the registry token the store's reference was taken
+;; against (see `release-pool!`). Absent for backings built by hand, which then
+;; release without the stale check.
 (defrecord JDBCTable [db-spec connection table read-cache]
   ;; The database evaluates the comparison — one statement, atomic on its own — so
   ;; konserve adds no mechanism of its own: no sidecar row, no lock. Declared
@@ -589,8 +803,17 @@
     (if (:sync? env) nil (go-try- nil)))
   (-delete-store [_ env]
     (async+sync (:sync? env) *default-sync-translation*
-                (go-try- (jdbc/execute! connection (delete-statement (:dbtype db-spec) table))
-                         (.close ^Connection connection))))
+                (go-try- (try
+                           (jdbc/execute! connection (delete-statement (:dbtype db-spec) table))
+                           (finally
+                             ;; Only a connection this store owns outright gets
+                             ;; closed, and it is closed even when the DROP
+                             ;; fails. When the backing holds a pooled DataSource
+                             ;; it is shared with every other store on this
+                             ;; database -- closing it here would take them all
+                             ;; down, and `release` is the way to hand it back.
+                             (when (instance? Connection connection)
+                               (.close ^Connection connection)))))))
   (-keys [_ env]
     (async+sync (:sync? env) *default-sync-translation*
                 (go-try-
@@ -792,24 +1015,9 @@
                     db-spec
                     (assoc db-spec :dbtype (:subprotocol db-spec)))
           db-spec (assoc db-spec :sync? (:sync? complete-opts))
-          ^PooledDataSource connection (get-connection db-spec)
-          backing (JDBCTable. db-spec connection table (atom {}))
-          ;; `:config` IS forwarded now. It used to be dissoc'd, so the
-          ;; literal above always won and compression and encryption could not
-          ;; be configured at all -- the blob header carried a 0 whatever was
-          ;; asked for. Merged onto the defaults, so a partial `:config` keeps
-          ;; the rest.
-          ;;
-          ;; `:compressor null-compressor` / `:encryptor null-encryptor` are
-          ;; gone: `connect-default-store` has never read them, taking both
-          ;; from `(get-in config [:compressor :type])`. Dead keys that made a
-          ;; top-level spelling look supported.
-          ;;
-          ;; Normalised BEFORE our serializer default is filled: emitting
-          ;; `:default-serializer` would trip konserve 0.9.369's deprecation
-          ;; warning on every connect whatever the caller passed, and filling
-          ;; first would let it occupy the slot and silently drop a caller's
-          ;; older spelling.
+          ;; Config is refused BEFORE a pool reference is taken: a throw past
+          ;; this point has to hand the reference back, and this one does not
+          ;; need one in the first place.
           _ (when (false? (:in-place? (:config params)))
               ;; Refused rather than honoured, because this backing cannot do it.
               ;; The layout writes `<key>.new` and then renames it over `<key>`,
@@ -829,6 +1037,25 @@
                                    "the primary key, and a conditional write could not be fenced.")
                               {:type :konserve.jdbc/unsupported-config
                                :config (:config params)})))
+          [^PooledDataSource connection pool-token] (acquire-pool db-spec)
+          backing (with-meta (JDBCTable. db-spec connection table (atom {}))
+                    {:state (atom {:released? false :pool pool-token})})
+          ;; `:config` IS forwarded now. It used to be dissoc'd, so the
+          ;; literal above always won and compression and encryption could not
+          ;; be configured at all -- the blob header carried a 0 whatever was
+          ;; asked for. Merged onto the defaults, so a partial `:config` keeps
+          ;; the rest.
+          ;;
+          ;; `:compressor null-compressor` / `:encryptor null-encryptor` are
+          ;; gone: `connect-default-store` has never read them, taking both
+          ;; from `(get-in config [:compressor :type])`. Dead keys that made a
+          ;; top-level spelling look supported.
+          ;;
+          ;; Normalised BEFORE our serializer default is filled: emitting
+          ;; `:default-serializer` would trip konserve 0.9.369's deprecation
+          ;; warning on every connect whatever the caller passed, and filling
+          ;; first would let it occupy the slot and silently drop a caller's
+          ;; older spelling.
           config (-> (dissoc params :opts :config)
                      (assoc :config (merge {:sync-blob? true
                                             :in-place? true
@@ -840,23 +1067,58 @@
                                 #(merge {:serializer :FressianSerializer} %))
                      (update :buffer-size #(or % (* 1024 1024)))
                      (assoc :opts complete-opts))]
-      (connect-default-store backing config))))
+      ;; The reference was taken above; if building the store on top of it
+      ;; fails, hand it straight back. Otherwise every failed connect -- a bad
+      ;; table name, a privilege error, a retry loop against a flaky database --
+      ;; pins the shared pool open with a reference nobody can release.
+      (try
+        (connect-default-store backing config)
+        (catch Throwable t
+          (release-pool! db-spec :token pool-token)
+          (throw t))))))
 
 (def connect-jdbc-store connect-store) ;; this is the new standard approach for store. Old signature remains for backwards compatability. 
 
 (defn release
-  "Must be called after work on database has finished in order to close connection"
+  "Hand back this store's reference to its connection pool. Must be called when
+   work on the store has finished.
+
+   The pool is shared with every other store on the same database, so it is only
+   closed once the last store using it has been released. Returns `:closed`,
+   `:retained`, `:absent`, `:already-released` or `:stale` (the pool this store
+   was opened against has since been closed out of band and rebuilt; the
+   store's reference no longer counts and nothing is closed).
+
+   `{:force? true}` in `env` closes the shared pool regardless of who else is
+   using it -- the pre-refcount behaviour, appropriate at process shutdown and
+   nowhere else."
   [store env]
   (async+sync (:sync? env) *default-sync-translation*
               (go-try-
-               (.close ^PooledDataSource (:connection ^JDBCTable (:backing store)))
-               (remove-from-pool (:db-spec ^JDBCTable (:backing store))))))
+               (let [backing ^JDBCTable (:backing store)
+                     state (:state (meta backing))
+                     ;; claim the release: only the first caller gives the
+                     ;; reference back, however often `release` is called
+                     already? (when state
+                                (:released? (first (swap-vals! state assoc :released? true))))]
+                 (if already?
+                   :already-released
+                   (release-pool! (:db-spec backing)
+                                  :force? (:force? env)
+                                  :token (some-> state deref :pool)))))))
 
-(defn delete-store [db-spec & {:keys [table opts]}]
+(defn delete-store
+  "Drop the store's table. Uses a connection of its own rather than the shared
+   pool, so deleting one tenant's store leaves every other store on the database
+   untouched."
+  [db-spec & {:keys [table opts]}]
   (let [complete-opts (merge {:sync? true} opts)
         table (or table (:table db-spec) default-table)
-        connection (jdbc/get-connection (prepare-spec db-spec))
-        backing (JDBCTable. db-spec connection table (atom {}))]
+        ;; the prepared spec, so `:jdbcUrl`-only callers get their dialect
+        ;; normalised (`postgres` -> `postgresql`) before the DROP is built
+        prepared (prepare-spec db-spec)
+        connection (jdbc/get-connection prepared)
+        backing (JDBCTable. prepared connection table (atom {}))]
     (-delete-store backing complete-opts)))
 
 ;; =============================================================================

--- a/test/konserve_jdbc/core_h2_test.clj
+++ b/test/konserve_jdbc/core_h2_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.core.async :refer [<!!]]
             [konserve.compliance-test :refer [compliance-test]]
-            [konserve-jdbc.core :refer [release]]
+            [konserve-jdbc.core :as jc :refer [release]]
+            [konserve.core :as k]
             [konserve.store :as store]
             [konserve-jdbc.util :refer [with-dir test-multi-operations-sync
                                         test-multi-operations-async
@@ -126,3 +127,159 @@
       (test-only-a-fenced-write-deposits #(store/connect-store spec {:sync? true})
                                          #(release % {:sync? true})))
     (store/delete-store spec {:sync? true})))
+
+;; ---------------------------------------------------------------------------
+;; Connection pool lifecycle
+;;
+;; The pool is shared by every store on a database, so releasing one store must
+;; not close it for the others. This is the downstream failure that motivated
+;; the refcount: datahike's `create-database`/`delete-database` release their
+;; store when done, which used to close the pool every other tenant was using.
+;; ---------------------------------------------------------------------------
+
+(def tenant-spec
+  (assoc db-spec :dbname "./tmp/h2/tenants;DB_CLOSE_ON_EXIT=FALSE"))
+
+(defn- tenant-pools
+  "The registry entries belonging to `tenant-spec`'s database."
+  []
+  (into {}
+        (filter (fn [[_ {:keys [db-spec]}]]
+                  (= (:dbname db-spec) (:dbname tenant-spec))))
+        (jc/pool-status)))
+
+(defn- tenant-refs []
+  (some-> (first (vals (tenant-pools))) :refs))
+
+(defn- roundtrips? [store k]
+  (k/assoc store k {:written k} {:sync? true})
+  (= {:written k} (k/get store k nil {:sync? true})))
+
+(deftest pool-is-refcounted-test
+  (testing "two stores on one database share one pool, released independently"
+    (let [a (jc/connect-store (assoc tenant-spec :table "tenant_a") :opts {:sync? true})
+          b (jc/connect-store (assoc tenant-spec :table "tenant_b") :opts {:sync? true})]
+      (is (= 1 (count (tenant-pools))) "one pool per database, not per table")
+      (is (= 2 (tenant-refs)))
+      (is (= :retained (jc/release a {:sync? true})) "a co-tenant still holds the pool")
+      (is (= 1 (tenant-refs)))
+      (is (roundtrips? b :b) "releasing one store leaves the other working")
+      (is (= :already-released (jc/release a {:sync? true}))
+          "a second release must not hand back a reference twice")
+      (is (= 1 (tenant-refs)))
+      (is (roundtrips? b :b-again))
+      (is (= :closed (jc/release b {:sync? true})) "the last holder closes the pool")
+      (is (empty? (tenant-pools)))
+      (jc/delete-store (assoc tenant-spec :table "tenant_a") :opts {:sync? true})
+      (jc/delete-store (assoc tenant-spec :table "tenant_b") :opts {:sync? true}))))
+
+(deftest delete-store-leaves-co-tenants-alive-test
+  (testing "deleting one tenant's store does not close the shared pool (downstream reproducer)"
+    (let [a (jc/connect-store (assoc tenant-spec :table "doomed") :opts {:sync? true})
+          b (jc/connect-store (assoc tenant-spec :table "survivor") :opts {:sync? true})]
+      (is (roundtrips? b :before))
+      (jc/release a {:sync? true})
+      (jc/delete-store (assoc tenant-spec :table "doomed") :opts {:sync? true})
+      (is (roundtrips? b :after) "the surviving store still works after a sibling is deleted")
+      (is (= :closed (jc/release b {:sync? true})))
+      (jc/delete-store (assoc tenant-spec :table "survivor") :opts {:sync? true}))))
+
+(deftest force-release-and-recovery-test
+  (testing ":force? closes a pool others still hold, and the next connect rebuilds it"
+    (let [a (jc/connect-store (assoc tenant-spec :table "forced_a") :opts {:sync? true})
+          _ (jc/connect-store (assoc tenant-spec :table "forced_b") :opts {:sync? true})]
+      (is (= 2 (tenant-refs)))
+      (is (= :closed (jc/release a {:sync? true :force? true})))
+      (is (empty? (tenant-pools)))
+      (let [b2 (jc/connect-store (assoc tenant-spec :table "forced_b" :validate-pool? true)
+                                 :opts {:sync? true})]
+        (is (roundtrips? b2 :recovered) "a fresh pool is built rather than a dead one handed out")
+        (is (= :closed (jc/release b2 {:sync? true})))
+        (jc/delete-store (assoc tenant-spec :table "forced_a") :opts {:sync? true})
+        (jc/delete-store (assoc tenant-spec :table "forced_b") :opts {:sync? true})))))
+
+(deftest failed-connect-releases-reference-test
+  (testing "a connect that fails after taking a pool reference hands it back"
+    (let [a (jc/connect-store (assoc tenant-spec :table "good") :opts {:sync? true})]
+      (is (= 1 (tenant-refs)))
+      (dotimes [_ 5]
+        (is (thrown? Exception
+                     (jc/connect-store (assoc tenant-spec :table "bad name!!") :opts {:sync? true}))))
+      (is (= 1 (tenant-refs)) "failed connects must not pin the shared pool open")
+      (is (= :closed (jc/release a {:sync? true})))
+      (is (empty? (tenant-pools)))
+      (jc/delete-store (assoc tenant-spec :table "good") :opts {:sync? true}))))
+
+(deftest sync-and-async-share-one-pool-test
+  (testing "the same database connected sync and async is one pool, not two"
+    (let [a (jc/connect-store (assoc tenant-spec :table "mode_a") :opts {:sync? true})
+          b (<!! (jc/connect-store (assoc tenant-spec :table "mode_b") :opts {:sync? false}))]
+      (is (= 1 (count (tenant-pools))))
+      (is (= 2 (tenant-refs)))
+      (is (= :retained (jc/release a {:sync? true})))
+      (is (= :closed (<!! (jc/release b {:sync? false}))))
+      (jc/delete-store (assoc tenant-spec :table "mode_a") :opts {:sync? true})
+      (jc/delete-store (assoc tenant-spec :table "mode_b") :opts {:sync? true}))))
+
+(deftest caller-spec-addresses-the-pool-test
+  (testing "release-pool! and remove-from-pool work with the spec the caller connected with"
+    (let [a (jc/connect-store (assoc tenant-spec :table "addr") :opts {:sync? true})]
+      (is (= 1 (tenant-refs)))
+      (jc/remove-from-pool tenant-spec)
+      (is (empty? (tenant-pools)) "the caller's own spec must address the pool")
+      (is (roundtrips? a :forgotten-but-alive))
+      (is (= :absent (jc/release a {:sync? true})))
+      (jc/delete-store (assoc tenant-spec :table "addr") :opts {:sync? true}))))
+
+(deftest stale-holder-cannot-close-rebuilt-pool-test
+  (testing "after an out-of-band close and rebuild, old holders' releases are no-ops"
+    (let [spec (assoc tenant-spec :validate-pool? true)
+          a (jc/connect-store (assoc spec :table "stale_a") :opts {:sync? true})
+          b (jc/connect-store (assoc spec :table "stale_b") :opts {:sync? true})]
+      (is (= 2 (tenant-refs)))
+      (is (= :closed (jc/release-pool! tenant-spec :force? true)) "simulated out-of-band close")
+      (let [c (jc/connect-store (assoc spec :table "stale_c") :opts {:sync? true})]
+        (is (= 1 (tenant-refs)))
+        (is (= :stale (jc/release a {:sync? true})) "a's reference was against the dead pool")
+        (is (= 1 (tenant-refs)))
+        (is (roundtrips? c :survives-stale-release) "the rebuilt pool is still open")
+        (is (= :stale (jc/release b {:sync? true})))
+        (is (= :closed (jc/release c {:sync? true})))
+        (is (empty? (tenant-pools))))
+      (doseq [t ["stale_a" "stale_b" "stale_c"]]
+        (jc/delete-store (assoc tenant-spec :table t) :opts {:sync? true})))))
+
+(deftest hand-built-backing-releases-test
+  (testing "a JDBCTable built by hand, with no lifecycle metadata, still releases"
+    (let [backing (jc/->JDBCTable tenant-spec nil "hand_built" (atom {}))]
+      (is (nil? (:state (meta backing))))
+      (is (= :absent (jc/release {:backing backing} {:sync? true}))))))
+
+(deftest ^:scale pool-scale-test
+  (testing "1000 concurrent tenants share one deliberately small pool"
+    (let [spec (assoc tenant-spec
+                      :dbname "./tmp/h2/scale;DB_CLOSE_ON_EXIT=FALSE"
+                      ;; a small pool with a real timeout: if the refcount ever
+                      ;; regressed into a pool-per-store, this would exhaust the
+                      ;; database rather than hang forever
+                      :maxPoolSize 8 :minPoolSize 2 :checkoutTimeout 30000)
+          tenants 1000
+          stores (mapv deref
+                       (doall (for [i (range tenants)]
+                                (future (jc/connect-store (assoc spec :table (str "scale_" (mod i 10)))
+                                                          :opts {:sync? true})))))
+          pools (into {}
+                      (filter (fn [[_ {:keys [db-spec]}]] (= (:dbname db-spec) (:dbname spec))))
+                      (jc/pool-status))]
+      (is (= tenants (count stores)))
+      (is (= 1 (count pools)) "one pool for a thousand tenants")
+      (is (= tenants (:refs (first (vals pools)))))
+      (let [survivor (first stores)
+            results (mapv deref (doall (for [s (rest stores)]
+                                         (future (jc/release s {:sync? true})))))]
+        (is (= {:retained (dec tenants)} (frequencies results))
+            "no release but the last one closes anything")
+        (is (roundtrips? survivor :survivor) "the last tenant standing still works")
+        (is (= :closed (jc/release survivor {:sync? true}))))
+      (doseq [t (range 10)]
+        (jc/delete-store (assoc spec :table (str "scale_" t)) :opts {:sync? true})))))

--- a/test/konserve_jdbc/datahike_multitenant_test.clj
+++ b/test/konserve_jdbc/datahike_multitenant_test.clj
@@ -1,0 +1,93 @@
+(ns konserve-jdbc.datahike-multitenant-test
+  "Multi-tenancy through datahike: one H2 database, one datahike database per
+   tenant, each on its own table. Datahike releases the konserve store at the
+   end of `create-database` and `delete-database`; before the pool was reference
+   counted, that closed the shared c3p0 pool under every other tenant."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [konserve-jdbc.core :as jc]
+            [konserve-jdbc.util :refer [with-dir]]))
+
+(def dir "./tmp/h2-datahike")
+
+(use-fixtures :once (fn [f] (with-dir dir f)))
+
+(def db-spec
+  {:backend :jdbc
+   :dbtype "h2"
+   :dbname (str "./" dir "/tenants;DB_CLOSE_ON_EXIT=FALSE")
+   :user "sa"
+   :password ""})
+
+(defn tenant-config [n]
+  {:store (assoc db-spec
+                 :table (str "tenant_" n)
+                 :id (java.util.UUID/nameUUIDFromBytes (.getBytes (str "tenant-" n))))
+   :keep-history? false
+   :schema-flexibility :read})
+
+(defn- tenant-pools []
+  (into {}
+        (filter (fn [[_ entry]] (= (:dbname (:db-spec entry)) (:dbname db-spec))))
+        (jc/pool-status)))
+
+(defn- tenant-refs [] (some-> (first (vals (tenant-pools))) :refs))
+
+(defn- eventually
+  "Datahike's `release` hands the store back through `konserve.store/release-store`
+   with its default `{:sync? false}`, so our reference comes back on a core.async
+   thread a moment after `d/release` returns. Poll for the expected registry
+   state rather than asserting it synchronously."
+  [pred]
+  (let [deadline (+ (System/currentTimeMillis) 5000)]
+    (loop []
+      (cond
+        (pred) true
+        (> (System/currentTimeMillis) deadline) (pred)
+        :else (do (Thread/sleep 20) (recur))))))
+
+(defn- writes-and-reads? [conn n]
+  (d/transact conn [{:tenant n :note (str "hello from " n)}])
+  (= #{[(str "hello from " n)]}
+     (d/q '[:find ?note :in $ ?t :where [?e :tenant ?t] [?e :note ?note]] @conn n)))
+
+(deftest datahike-tenants-share-one-pool-test
+  (testing "N datahike databases on one H2 file share one pool and survive each other's lifecycle"
+    (let [tenants (range 5)
+          cfgs (mapv tenant-config tenants)]
+      (doseq [c cfgs] (d/create-database c))
+      ;; create-database released its store each time; nothing should be held
+      (is (eventually #(empty? (tenant-pools))) "create-database balances its own reference")
+
+      (let [conns (mapv d/connect cfgs)]
+        (is (= 1 (count (tenant-pools))) "five tenants, one pool")
+        (is (= (count tenants) (tenant-refs)) "one reference per live connection")
+        (doseq [[conn n] (map vector conns tenants)]
+          (is (writes-and-reads? conn n) (str "tenant " n " round-trips")))
+
+        (testing "deleting one tenant leaves the others' connections working"
+          (d/release (first conns))
+          (is (eventually #(= (dec (count tenants)) (tenant-refs))) "release hands back one reference")
+          (d/delete-database (first cfgs))
+          (is (eventually #(= (dec (count tenants)) (tenant-refs))) "delete-database balances its own")
+          (doseq [[conn n] (rest (map vector conns tenants))]
+            (is (writes-and-reads? conn n) (str "tenant " n " still works after a sibling was deleted"))))
+
+        (testing "creating a new tenant while others are live leaves them working"
+          (let [new-cfg (tenant-config 99)]
+            (d/create-database new-cfg)
+            (let [new-conn (d/connect new-cfg)]
+              (is (writes-and-reads? new-conn 99))
+              (is (= (count tenants) (tenant-refs)) "four survivors plus the newcomer")
+              (doseq [[conn n] (rest (map vector conns tenants))]
+                (is (writes-and-reads? conn n)))
+              (d/release new-conn)
+              (d/delete-database new-cfg)
+              (is (eventually #(= (dec (count tenants)) (tenant-refs)))))))
+
+        (testing "releasing every connection closes the pool"
+          (doseq [conn (rest conns)] (d/release conn))
+          (is (eventually #(empty? (tenant-pools))))))
+
+      (doseq [c (rest cfgs)] (d/delete-database c))
+      (is (eventually #(empty? (tenant-pools))) "delete-database balances its own reference"))))


### PR DESCRIPTION
One c3p0 pool per database, shared by every store on it, and reference counted so that releasing one store no longer closes the pool under the others. Reported downstream: datahike's create-database/delete-database release their store when done, which took every other tenant on the server down with them. connect-store takes a reference, release gives one back, the pool closes when the last holder lets go. release is idempotent per store and returns :closed / :retained / :already-released / :absent / :stale; {:force? true} restores the old unconditional close.

Stress-tested the error and recovery paths (24 threads x 40 mixed sync/async connect/write/release cycles, 0 errors, registry empty):

- A connect that fails after taking its reference hands it back, so a retry loop against a bad table name or a flaky database cannot pin the shared pool open.
- References carry the registry token they were taken against; after a :validate-pool? rebuild a stale holder's release returns :stale and cannot close the pool the new holders are using.
- :sync? is not part of the pool key. It never affected the pool, and keying on it gave one database two pools as soon as sync and async stores were mixed.
- Shutdown hooks are removed when a pool closes (they leaked before); -delete-store no longer closes a pooled DataSource and closes an owned connection in a finally; delete-store uses the prepared spec so a :jdbcUrl-only config gets its dialect normalised before the DROP.

Per-store lifecycle state (:released?, pool token) rides in JDBCTable's metadata rather than a new field, so the positional constructor is unchanged and datahike-jdbc needs no change. New: pool-status (a credential-free registry snapshot), release-pool!, remove-from-pool now forgets without closing, :validate-pool? probes and rebuilds a pool closed out of band. c3p0 sizing keys in the store config are applied when the pool is built; a later store asking for different values is logged and ignored.

Tests: pool lifecycle and one regression per finding in core_h2_test, plus datahike_multitenant_test driving konserve-jdbc purely through datahike.api -- five tenants on one H2 file, create/connect/delete a sibling, the survivors keep working and one pool backs them all. Reproduces the downstream failure on main ("has been closed()"). datahike 0.8.1790 is added to the :test alias only.